### PR TITLE
Jakarta namespace migration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,72 +2,55 @@
 
 # xjc-non-null-getter
 
-Maven JAXB2 Plugin that adds getters, creating the corresponding object, and adding it to the attribute if null
+Maven JAXB2 Plugin that adds getters, creating the corresponding object, and adding it to the attribute if null.
+
+It requires Java 17.
 
 ## Usage in maven pom.xml
 
 In pom.xml, add the plugin:
 ```xml
-            <plugin>
-                <groupId>org.jvnet.jaxb2.maven2</groupId>
-                <artifactId>maven-jaxb2-plugin</artifactId>
-                <version>0.14.0</version>
-                <configuration>
-                    <strict>false</strict>
-                    <!--
-                     see https://github.com/highsource/maven-jaxb2-plugin/wiki/Catalogs-in-Strict-Mode
-                    -->
-                    <schemaDirectory>${basedir}/src/main/resources/xsd/</schemaDirectory>
-                    <generatePackage>ch.vd.cyber.backofficebe.sms</generatePackage>
-                    <schemaIncludes>
-                        <include>sms-v1.xsd</include>
-                    </schemaIncludes>
-                    <args>
-                        <arg>-extension</arg>
-                        <arg>-Xvalue-constructor</arg>
-                        <arg>-XNonNullGetter-api</arg>
-                    </args>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.jvnet.jaxb2_commons</groupId>
-                        <artifactId>jaxb2-value-constructor</artifactId>
-                        <version>${jaxb2-value-constructor.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>ch.dsivd.jaxb-plugins</groupId>
-                        <artifactId>xjc-non-null-getter</artifactId>
-                        <version>${xjc-non-null-getter.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-```
-
-For JDK11, you may add to your pom.xml :
-
-```xml
-<dependency>
-    <groupId>jakarta.xml.bind</groupId>
-    <artifactId>jakarta.xml.bind-api</artifactId>
-    <version>${jaxb.version}</version>
-</dependency>
-<dependency>
-    <groupId>org.glassfish.jaxb</groupId>
-    <artifactId>jaxb-runtime</artifactId>
-    <version>${jaxb.version}</version>
-</dependency>
-
-<properties>
-     <java.version>11</java.version>
-     <jaxb.version>2.3.2</jaxb.version>
- </properties>
+<plugin>
+    <groupId>org.jvnet.jaxb</groupId>
+    <artifactId>jaxb-maven-plugin</artifactId>
+    <version>3.0.1</version>
+    <configuration>
+        <strict>false</strict> <!-- see https://github.com/highsource/maven-jaxb2-plugin/wiki/Catalogs-in-Strict-Mode -->
+        <schemaDirectory>src/main/resources/xsd</schemaDirectory>
+        <schemaIncludes>
+            <include>main.xsd</include>
+        </schemaIncludes>
+        <catalog>src/main/resources/catalog.xml</catalog>
+        <bindingDirectory>src/main/resources</bindingDirectory>
+        <bindingIncludes>
+            <include>bindings.xml</include>
+        </bindingIncludes>
+        <args>
+            <arg>-extension</arg>
+            <arg>-Xvalue-constructor</arg>
+            <arg>-XNonNullGetter-api</arg>
+        </args>
+    </configuration>
+    <executions>
+        <execution>
+            <goals>
+                <goal>generate</goal>
+            </goals>
+        </execution>
+    </executions>
+    <dependencies>
+        <dependency>
+            <groupId>org.jvnet.jaxb</groupId>
+            <artifactId>jaxb-plugins</artifactId>
+            <version>${jaxb-plugins.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.dsivd.jaxb-plugins</groupId>
+            <artifactId>xjc-non-null-getter</artifactId>
+            <version>${xjc-non-null-getter.version}</version>
+        </dependency>
+    </dependencies>
+</plugin>
 ```
 
 ## Usage in Java code

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -136,16 +136,6 @@
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
-                <configuration>
-                    <encoding>UTF-8</encoding>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 
@@ -166,9 +156,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
 
-        <jaxb.version>2.3.2</jaxb.version>
+        <jaxb.version>4.0.4</jaxb.version>
     </properties>
 
 </project>

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/InhabitantControlType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/InhabitantControlType.java
@@ -1,40 +1,41 @@
 
 package ch.ech.xmlns.ech_0006._2;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for inhabitantControlType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="inhabitantControlType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *     &lt;enumeration value="0102"/&gt;
- *     &lt;enumeration value="0201"/&gt;
- *     &lt;enumeration value="0202"/&gt;
- *     &lt;enumeration value="0301"/&gt;
- *     &lt;enumeration value="0302"/&gt;
- *     &lt;enumeration value="0401"/&gt;
- *     &lt;enumeration value="0402"/&gt;
- *     &lt;enumeration value="0503"/&gt;
- *     &lt;enumeration value="0601"/&gt;
- *     &lt;enumeration value="0602"/&gt;
- *     &lt;enumeration value="0701"/&gt;
- *     &lt;enumeration value="0702"/&gt;
- *     &lt;enumeration value="0804"/&gt;
- *     &lt;enumeration value="0905"/&gt;
- *     &lt;enumeration value="1006"/&gt;
- *     &lt;enumeration value="1108"/&gt;
- *     &lt;enumeration value="1208"/&gt;
- *     &lt;enumeration value="1300"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for inhabitantControlType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="inhabitantControlType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     <enumeration value="0102"/>
+ *     <enumeration value="0201"/>
+ *     <enumeration value="0202"/>
+ *     <enumeration value="0301"/>
+ *     <enumeration value="0302"/>
+ *     <enumeration value="0401"/>
+ *     <enumeration value="0402"/>
+ *     <enumeration value="0503"/>
+ *     <enumeration value="0601"/>
+ *     <enumeration value="0602"/>
+ *     <enumeration value="0701"/>
+ *     <enumeration value="0702"/>
+ *     <enumeration value="0804"/>
+ *     <enumeration value="0905"/>
+ *     <enumeration value="1006"/>
+ *     <enumeration value="1108"/>
+ *     <enumeration value="1208"/>
+ *     <enumeration value="1300"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "inhabitantControlType")
@@ -83,10 +84,26 @@ public enum InhabitantControlType {
         value = v;
     }
 
+    /**
+     * Gets the value associated to the enum constant.
+     * 
+     * @return
+     *     The value linked to the enum.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Gets the enum associated to the value passed as parameter.
+     * 
+     * @param v
+     *     The value to get the enum from.
+     * @return
+     *     The enum which corresponds to the value, if it exists.
+     * @throws IllegalArgumentException
+     *     If no value matches in the enum declaration.
+     */
     public static InhabitantControlType fromValue(String v) {
         for (InhabitantControlType c: InhabitantControlType.values()) {
             if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/ObjectFactory.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/ObjectFactory.java
@@ -1,14 +1,14 @@
 
 package ch.ech.xmlns.ech_0006._2;
 
-import javax.xml.bind.annotation.XmlRegistry;
+import jakarta.xml.bind.annotation.XmlRegistry;
 
 
 /**
  * This object contains factory methods for each 
  * Java content interface and Java element interface 
  * generated in the ch.ech.xmlns.ech_0006._2 package. 
- * <p>An ObjectFactory allows you to programatically 
+ * <p>An ObjectFactory allows you to programmatically 
  * construct new instances of the Java representation 
  * for XML content. The Java representation of XML 
  * content can consist of schema derived interfaces 
@@ -32,6 +32,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link PermitRoot }
      * 
+     * @return
+     *     the new instance of {@link PermitRoot }
      */
     public PermitRoot createPermitRoot() {
         return new PermitRoot();

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/PermitRoot.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/PermitRoot.java
@@ -1,36 +1,36 @@
 
 package ch.ech.xmlns.ech_0006._2;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for anonymous complex type.
+ * <p>Java class for anonymous complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="residencePermitCategory" type="{http://www.ech.ch/xmlns/eCH-0006/2}residencePermitCategoryType" minOccurs="0"/&gt;
- *         &lt;element name="residencePermitRuling" type="{http://www.ech.ch/xmlns/eCH-0006/2}residencePermitRulingType" minOccurs="0"/&gt;
- *         &lt;element name="residencePermitBorder" type="{http://www.ech.ch/xmlns/eCH-0006/2}residencePermitBorderType" minOccurs="0"/&gt;
- *         &lt;element name="residencePermitShortType" type="{http://www.ech.ch/xmlns/eCH-0006/2}residencePermitShortType" minOccurs="0"/&gt;
- *         &lt;element name="residencePermit" type="{http://www.ech.ch/xmlns/eCH-0006/2}residencePermitType" minOccurs="0"/&gt;
- *         &lt;element name="inhabitantControl" type="{http://www.ech.ch/xmlns/eCH-0006/2}inhabitantControlType" minOccurs="0"/&gt;
- *         &lt;element name="residencePermitDetailedType" type="{http://www.ech.ch/xmlns/eCH-0006/2}residencePermitDetailedType" minOccurs="0"/&gt;
- *         &lt;element name="residencePermitToBeRegisteredType" type="{http://www.ech.ch/xmlns/eCH-0006/2}residencePermitToBeRegisteredType" minOccurs="0"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType>
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="residencePermitCategory" type="{http://www.ech.ch/xmlns/eCH-0006/2}residencePermitCategoryType" minOccurs="0"/>
+ *         <element name="residencePermitRuling" type="{http://www.ech.ch/xmlns/eCH-0006/2}residencePermitRulingType" minOccurs="0"/>
+ *         <element name="residencePermitBorder" type="{http://www.ech.ch/xmlns/eCH-0006/2}residencePermitBorderType" minOccurs="0"/>
+ *         <element name="residencePermitShortType" type="{http://www.ech.ch/xmlns/eCH-0006/2}residencePermitShortType" minOccurs="0"/>
+ *         <element name="residencePermit" type="{http://www.ech.ch/xmlns/eCH-0006/2}residencePermitType" minOccurs="0"/>
+ *         <element name="inhabitantControl" type="{http://www.ech.ch/xmlns/eCH-0006/2}inhabitantControlType" minOccurs="0"/>
+ *         <element name="residencePermitDetailedType" type="{http://www.ech.ch/xmlns/eCH-0006/2}residencePermitDetailedType" minOccurs="0"/>
+ *         <element name="residencePermitToBeRegisteredType" type="{http://www.ech.ch/xmlns/eCH-0006/2}residencePermitToBeRegisteredType" minOccurs="0"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/ResidencePermitBorderType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/ResidencePermitBorderType.java
@@ -1,24 +1,25 @@
 
 package ch.ech.xmlns.ech_0006._2;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for residencePermitBorderType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="residencePermitBorderType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *     &lt;enumeration value="01"/&gt;
- *     &lt;enumeration value="02"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for residencePermitBorderType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="residencePermitBorderType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     <enumeration value="01"/>
+ *     <enumeration value="02"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "residencePermitBorderType")
@@ -35,10 +36,26 @@ public enum ResidencePermitBorderType {
         value = v;
     }
 
+    /**
+     * Gets the value associated to the enum constant.
+     * 
+     * @return
+     *     The value linked to the enum.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Gets the enum associated to the value passed as parameter.
+     * 
+     * @param v
+     *     The value to get the enum from.
+     * @return
+     *     The enum which corresponds to the value, if it exists.
+     * @throws IllegalArgumentException
+     *     If no value matches in the enum declaration.
+     */
     public static ResidencePermitBorderType fromValue(String v) {
         for (ResidencePermitBorderType c: ResidencePermitBorderType.values()) {
             if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/ResidencePermitCategoryType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/ResidencePermitCategoryType.java
@@ -1,35 +1,36 @@
 
 package ch.ech.xmlns.ech_0006._2;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for residencePermitCategoryType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="residencePermitCategoryType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *     &lt;enumeration value="01"/&gt;
- *     &lt;enumeration value="02"/&gt;
- *     &lt;enumeration value="03"/&gt;
- *     &lt;enumeration value="04"/&gt;
- *     &lt;enumeration value="05"/&gt;
- *     &lt;enumeration value="06"/&gt;
- *     &lt;enumeration value="07"/&gt;
- *     &lt;enumeration value="08"/&gt;
- *     &lt;enumeration value="09"/&gt;
- *     &lt;enumeration value="10"/&gt;
- *     &lt;enumeration value="11"/&gt;
- *     &lt;enumeration value="12"/&gt;
- *     &lt;enumeration value="13"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for residencePermitCategoryType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="residencePermitCategoryType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     <enumeration value="01"/>
+ *     <enumeration value="02"/>
+ *     <enumeration value="03"/>
+ *     <enumeration value="04"/>
+ *     <enumeration value="05"/>
+ *     <enumeration value="06"/>
+ *     <enumeration value="07"/>
+ *     <enumeration value="08"/>
+ *     <enumeration value="09"/>
+ *     <enumeration value="10"/>
+ *     <enumeration value="11"/>
+ *     <enumeration value="12"/>
+ *     <enumeration value="13"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "residencePermitCategoryType")
@@ -68,10 +69,26 @@ public enum ResidencePermitCategoryType {
         value = v;
     }
 
+    /**
+     * Gets the value associated to the enum constant.
+     * 
+     * @return
+     *     The value linked to the enum.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Gets the enum associated to the value passed as parameter.
+     * 
+     * @param v
+     *     The value to get the enum from.
+     * @return
+     *     The enum which corresponds to the value, if it exists.
+     * @throws IllegalArgumentException
+     *     If no value matches in the enum declaration.
+     */
     public static ResidencePermitCategoryType fromValue(String v) {
         for (ResidencePermitCategoryType c: ResidencePermitCategoryType.values()) {
             if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/ResidencePermitDetailedType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/ResidencePermitDetailedType.java
@@ -1,58 +1,59 @@
 
 package ch.ech.xmlns.ech_0006._2;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for residencePermitDetailedType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="residencePermitDetailedType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *     &lt;enumeration value="0102"/&gt;
- *     &lt;enumeration value="0201"/&gt;
- *     &lt;enumeration value="0202"/&gt;
- *     &lt;enumeration value="0301"/&gt;
- *     &lt;enumeration value="0302"/&gt;
- *     &lt;enumeration value="0401"/&gt;
- *     &lt;enumeration value="0402"/&gt;
- *     &lt;enumeration value="0503"/&gt;
- *     &lt;enumeration value="0601"/&gt;
- *     &lt;enumeration value="0602"/&gt;
- *     &lt;enumeration value="060101"/&gt;
- *     &lt;enumeration value="060201"/&gt;
- *     &lt;enumeration value="060102"/&gt;
- *     &lt;enumeration value="060202"/&gt;
- *     &lt;enumeration value="0701"/&gt;
- *     &lt;enumeration value="0702"/&gt;
- *     &lt;enumeration value="070101"/&gt;
- *     &lt;enumeration value="070201"/&gt;
- *     &lt;enumeration value="070102"/&gt;
- *     &lt;enumeration value="070202"/&gt;
- *     &lt;enumeration value="070103"/&gt;
- *     &lt;enumeration value="070104"/&gt;
- *     &lt;enumeration value="070204"/&gt;
- *     &lt;enumeration value="070105"/&gt;
- *     &lt;enumeration value="070205"/&gt;
- *     &lt;enumeration value="070206"/&gt;
- *     &lt;enumeration value="070907"/&gt;
- *     &lt;enumeration value="0804"/&gt;
- *     &lt;enumeration value="0905"/&gt;
- *     &lt;enumeration value="1006"/&gt;
- *     &lt;enumeration value="100601"/&gt;
- *     &lt;enumeration value="100602"/&gt;
- *     &lt;enumeration value="100603"/&gt;
- *     &lt;enumeration value="1107"/&gt;
- *     &lt;enumeration value="1208"/&gt;
- *     &lt;enumeration value="1300"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for residencePermitDetailedType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="residencePermitDetailedType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     <enumeration value="0102"/>
+ *     <enumeration value="0201"/>
+ *     <enumeration value="0202"/>
+ *     <enumeration value="0301"/>
+ *     <enumeration value="0302"/>
+ *     <enumeration value="0401"/>
+ *     <enumeration value="0402"/>
+ *     <enumeration value="0503"/>
+ *     <enumeration value="0601"/>
+ *     <enumeration value="0602"/>
+ *     <enumeration value="060101"/>
+ *     <enumeration value="060201"/>
+ *     <enumeration value="060102"/>
+ *     <enumeration value="060202"/>
+ *     <enumeration value="0701"/>
+ *     <enumeration value="0702"/>
+ *     <enumeration value="070101"/>
+ *     <enumeration value="070201"/>
+ *     <enumeration value="070102"/>
+ *     <enumeration value="070202"/>
+ *     <enumeration value="070103"/>
+ *     <enumeration value="070104"/>
+ *     <enumeration value="070204"/>
+ *     <enumeration value="070105"/>
+ *     <enumeration value="070205"/>
+ *     <enumeration value="070206"/>
+ *     <enumeration value="070907"/>
+ *     <enumeration value="0804"/>
+ *     <enumeration value="0905"/>
+ *     <enumeration value="1006"/>
+ *     <enumeration value="100601"/>
+ *     <enumeration value="100602"/>
+ *     <enumeration value="100603"/>
+ *     <enumeration value="1107"/>
+ *     <enumeration value="1208"/>
+ *     <enumeration value="1300"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "residencePermitDetailedType")
@@ -137,10 +138,26 @@ public enum ResidencePermitDetailedType {
         value = v;
     }
 
+    /**
+     * Gets the value associated to the enum constant.
+     * 
+     * @return
+     *     The value linked to the enum.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Gets the enum associated to the value passed as parameter.
+     * 
+     * @param v
+     *     The value to get the enum from.
+     * @return
+     *     The enum which corresponds to the value, if it exists.
+     * @throws IllegalArgumentException
+     *     If no value matches in the enum declaration.
+     */
     public static ResidencePermitDetailedType fromValue(String v) {
         for (ResidencePermitDetailedType c: ResidencePermitDetailedType.values()) {
             if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/ResidencePermitRulingType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/ResidencePermitRulingType.java
@@ -1,31 +1,32 @@
 
 package ch.ech.xmlns.ech_0006._2;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for residencePermitRulingType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="residencePermitRulingType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *     &lt;enumeration value="01"/&gt;
- *     &lt;enumeration value="02"/&gt;
- *     &lt;enumeration value="03"/&gt;
- *     &lt;enumeration value="04"/&gt;
- *     &lt;enumeration value="05"/&gt;
- *     &lt;enumeration value="06"/&gt;
- *     &lt;enumeration value="07"/&gt;
- *     &lt;enumeration value="08"/&gt;
- *     &lt;enumeration value="09"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for residencePermitRulingType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="residencePermitRulingType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     <enumeration value="01"/>
+ *     <enumeration value="02"/>
+ *     <enumeration value="03"/>
+ *     <enumeration value="04"/>
+ *     <enumeration value="05"/>
+ *     <enumeration value="06"/>
+ *     <enumeration value="07"/>
+ *     <enumeration value="08"/>
+ *     <enumeration value="09"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "residencePermitRulingType")
@@ -56,10 +57,26 @@ public enum ResidencePermitRulingType {
         value = v;
     }
 
+    /**
+     * Gets the value associated to the enum constant.
+     * 
+     * @return
+     *     The value linked to the enum.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Gets the enum associated to the value passed as parameter.
+     * 
+     * @param v
+     *     The value to get the enum from.
+     * @return
+     *     The enum which corresponds to the value, if it exists.
+     * @throws IllegalArgumentException
+     *     If no value matches in the enum declaration.
+     */
     public static ResidencePermitRulingType fromValue(String v) {
         for (ResidencePermitRulingType c: ResidencePermitRulingType.values()) {
             if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/ResidencePermitShortType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/ResidencePermitShortType.java
@@ -1,29 +1,30 @@
 
 package ch.ech.xmlns.ech_0006._2;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for residencePermitShortType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="residencePermitShortType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *     &lt;enumeration value="01"/&gt;
- *     &lt;enumeration value="02"/&gt;
- *     &lt;enumeration value="03"/&gt;
- *     &lt;enumeration value="04"/&gt;
- *     &lt;enumeration value="05"/&gt;
- *     &lt;enumeration value="06"/&gt;
- *     &lt;enumeration value="07"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for residencePermitShortType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="residencePermitShortType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     <enumeration value="01"/>
+ *     <enumeration value="02"/>
+ *     <enumeration value="03"/>
+ *     <enumeration value="04"/>
+ *     <enumeration value="05"/>
+ *     <enumeration value="06"/>
+ *     <enumeration value="07"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "residencePermitShortType")
@@ -50,10 +51,26 @@ public enum ResidencePermitShortType {
         value = v;
     }
 
+    /**
+     * Gets the value associated to the enum constant.
+     * 
+     * @return
+     *     The value linked to the enum.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Gets the enum associated to the value passed as parameter.
+     * 
+     * @param v
+     *     The value to get the enum from.
+     * @return
+     *     The enum which corresponds to the value, if it exists.
+     * @throws IllegalArgumentException
+     *     If no value matches in the enum declaration.
+     */
     public static ResidencePermitShortType fromValue(String v) {
         for (ResidencePermitShortType c: ResidencePermitShortType.values()) {
             if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/ResidencePermitToBeRegisteredType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/ResidencePermitToBeRegisteredType.java
@@ -1,25 +1,26 @@
 
 package ch.ech.xmlns.ech_0006._2;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for residencePermitToBeRegisteredType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="residencePermitToBeRegisteredType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *     &lt;enumeration value="01"/&gt;
- *     &lt;enumeration value="02"/&gt;
- *     &lt;enumeration value="03"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for residencePermitToBeRegisteredType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="residencePermitToBeRegisteredType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     <enumeration value="01"/>
+ *     <enumeration value="02"/>
+ *     <enumeration value="03"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "residencePermitToBeRegisteredType")
@@ -38,10 +39,26 @@ public enum ResidencePermitToBeRegisteredType {
         value = v;
     }
 
+    /**
+     * Gets the value associated to the enum constant.
+     * 
+     * @return
+     *     The value linked to the enum.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Gets the enum associated to the value passed as parameter.
+     * 
+     * @param v
+     *     The value to get the enum from.
+     * @return
+     *     The enum which corresponds to the value, if it exists.
+     * @throws IllegalArgumentException
+     *     If no value matches in the enum declaration.
+     */
     public static ResidencePermitToBeRegisteredType fromValue(String v) {
         for (ResidencePermitToBeRegisteredType c: ResidencePermitToBeRegisteredType.values()) {
             if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/ResidencePermitType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/ResidencePermitType.java
@@ -1,70 +1,71 @@
 
 package ch.ech.xmlns.ech_0006._2;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for residencePermitType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="residencePermitType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *     &lt;enumeration value="01"/&gt;
- *     &lt;enumeration value="0102"/&gt;
- *     &lt;enumeration value="02"/&gt;
- *     &lt;enumeration value="0201"/&gt;
- *     &lt;enumeration value="0202"/&gt;
- *     &lt;enumeration value="03"/&gt;
- *     &lt;enumeration value="0301"/&gt;
- *     &lt;enumeration value="0302"/&gt;
- *     &lt;enumeration value="04"/&gt;
- *     &lt;enumeration value="0401"/&gt;
- *     &lt;enumeration value="0402"/&gt;
- *     &lt;enumeration value="05"/&gt;
- *     &lt;enumeration value="0503"/&gt;
- *     &lt;enumeration value="06"/&gt;
- *     &lt;enumeration value="0601"/&gt;
- *     &lt;enumeration value="0602"/&gt;
- *     &lt;enumeration value="060101"/&gt;
- *     &lt;enumeration value="060201"/&gt;
- *     &lt;enumeration value="060102"/&gt;
- *     &lt;enumeration value="060202"/&gt;
- *     &lt;enumeration value="07"/&gt;
- *     &lt;enumeration value="0701"/&gt;
- *     &lt;enumeration value="0702"/&gt;
- *     &lt;enumeration value="070101"/&gt;
- *     &lt;enumeration value="070201"/&gt;
- *     &lt;enumeration value="070102"/&gt;
- *     &lt;enumeration value="070202"/&gt;
- *     &lt;enumeration value="070103"/&gt;
- *     &lt;enumeration value="070104"/&gt;
- *     &lt;enumeration value="070204"/&gt;
- *     &lt;enumeration value="070105"/&gt;
- *     &lt;enumeration value="070205"/&gt;
- *     &lt;enumeration value="070206"/&gt;
- *     &lt;enumeration value="070907"/&gt;
- *     &lt;enumeration value="08"/&gt;
- *     &lt;enumeration value="0804"/&gt;
- *     &lt;enumeration value="09"/&gt;
- *     &lt;enumeration value="0905"/&gt;
- *     &lt;enumeration value="10"/&gt;
- *     &lt;enumeration value="1006"/&gt;
- *     &lt;enumeration value="100601"/&gt;
- *     &lt;enumeration value="100602"/&gt;
- *     &lt;enumeration value="100603"/&gt;
- *     &lt;enumeration value="11"/&gt;
- *     &lt;enumeration value="1107"/&gt;
- *     &lt;enumeration value="12"/&gt;
- *     &lt;enumeration value="1208"/&gt;
- *     &lt;enumeration value="1300"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for residencePermitType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="residencePermitType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     <enumeration value="01"/>
+ *     <enumeration value="0102"/>
+ *     <enumeration value="02"/>
+ *     <enumeration value="0201"/>
+ *     <enumeration value="0202"/>
+ *     <enumeration value="03"/>
+ *     <enumeration value="0301"/>
+ *     <enumeration value="0302"/>
+ *     <enumeration value="04"/>
+ *     <enumeration value="0401"/>
+ *     <enumeration value="0402"/>
+ *     <enumeration value="05"/>
+ *     <enumeration value="0503"/>
+ *     <enumeration value="06"/>
+ *     <enumeration value="0601"/>
+ *     <enumeration value="0602"/>
+ *     <enumeration value="060101"/>
+ *     <enumeration value="060201"/>
+ *     <enumeration value="060102"/>
+ *     <enumeration value="060202"/>
+ *     <enumeration value="07"/>
+ *     <enumeration value="0701"/>
+ *     <enumeration value="0702"/>
+ *     <enumeration value="070101"/>
+ *     <enumeration value="070201"/>
+ *     <enumeration value="070102"/>
+ *     <enumeration value="070202"/>
+ *     <enumeration value="070103"/>
+ *     <enumeration value="070104"/>
+ *     <enumeration value="070204"/>
+ *     <enumeration value="070105"/>
+ *     <enumeration value="070205"/>
+ *     <enumeration value="070206"/>
+ *     <enumeration value="070907"/>
+ *     <enumeration value="08"/>
+ *     <enumeration value="0804"/>
+ *     <enumeration value="09"/>
+ *     <enumeration value="0905"/>
+ *     <enumeration value="10"/>
+ *     <enumeration value="1006"/>
+ *     <enumeration value="100601"/>
+ *     <enumeration value="100602"/>
+ *     <enumeration value="100603"/>
+ *     <enumeration value="11"/>
+ *     <enumeration value="1107"/>
+ *     <enumeration value="12"/>
+ *     <enumeration value="1208"/>
+ *     <enumeration value="1300"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "residencePermitType")
@@ -173,10 +174,26 @@ public enum ResidencePermitType {
         value = v;
     }
 
+    /**
+     * Gets the value associated to the enum constant.
+     * 
+     * @return
+     *     The value linked to the enum.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Gets the enum associated to the value passed as parameter.
+     * 
+     * @param v
+     *     The value to get the enum from.
+     * @return
+     *     The enum which corresponds to the value, if it exists.
+     * @throws IllegalArgumentException
+     *     If no value matches in the enum declaration.
+     */
     public static ResidencePermitType fromValue(String v) {
         for (ResidencePermitType c: ResidencePermitType.values()) {
             if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/package-info.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0006/_2/package-info.java
@@ -1,2 +1,2 @@
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.ech.ch/xmlns/eCH-0006/2", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://www.ech.ch/xmlns/eCH-0006/2", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package ch.ech.xmlns.ech_0006._2;

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0007/_3/CantonAbbreviationType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0007/_3/CantonAbbreviationType.java
@@ -1,48 +1,49 @@
 
 package ch.ech.xmlns.ech_0007._3;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for cantonAbbreviationType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="cantonAbbreviationType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}token"&gt;
- *     &lt;maxLength value="2"/&gt;
- *     &lt;enumeration value="ZH"/&gt;
- *     &lt;enumeration value="BE"/&gt;
- *     &lt;enumeration value="LU"/&gt;
- *     &lt;enumeration value="UR"/&gt;
- *     &lt;enumeration value="SZ"/&gt;
- *     &lt;enumeration value="OW"/&gt;
- *     &lt;enumeration value="NW"/&gt;
- *     &lt;enumeration value="GL"/&gt;
- *     &lt;enumeration value="ZG"/&gt;
- *     &lt;enumeration value="FR"/&gt;
- *     &lt;enumeration value="SO"/&gt;
- *     &lt;enumeration value="BS"/&gt;
- *     &lt;enumeration value="BL"/&gt;
- *     &lt;enumeration value="SH"/&gt;
- *     &lt;enumeration value="AR"/&gt;
- *     &lt;enumeration value="AI"/&gt;
- *     &lt;enumeration value="SG"/&gt;
- *     &lt;enumeration value="GR"/&gt;
- *     &lt;enumeration value="AG"/&gt;
- *     &lt;enumeration value="TG"/&gt;
- *     &lt;enumeration value="TI"/&gt;
- *     &lt;enumeration value="VD"/&gt;
- *     &lt;enumeration value="VS"/&gt;
- *     &lt;enumeration value="NE"/&gt;
- *     &lt;enumeration value="GE"/&gt;
- *     &lt;enumeration value="JU"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for cantonAbbreviationType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="cantonAbbreviationType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}token">
+ *     <maxLength value="2"/>
+ *     <enumeration value="ZH"/>
+ *     <enumeration value="BE"/>
+ *     <enumeration value="LU"/>
+ *     <enumeration value="UR"/>
+ *     <enumeration value="SZ"/>
+ *     <enumeration value="OW"/>
+ *     <enumeration value="NW"/>
+ *     <enumeration value="GL"/>
+ *     <enumeration value="ZG"/>
+ *     <enumeration value="FR"/>
+ *     <enumeration value="SO"/>
+ *     <enumeration value="BS"/>
+ *     <enumeration value="BL"/>
+ *     <enumeration value="SH"/>
+ *     <enumeration value="AR"/>
+ *     <enumeration value="AI"/>
+ *     <enumeration value="SG"/>
+ *     <enumeration value="GR"/>
+ *     <enumeration value="AG"/>
+ *     <enumeration value="TG"/>
+ *     <enumeration value="TI"/>
+ *     <enumeration value="VD"/>
+ *     <enumeration value="VS"/>
+ *     <enumeration value="NE"/>
+ *     <enumeration value="GE"/>
+ *     <enumeration value="JU"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "cantonAbbreviationType")

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0007/_3/CantonFlAbbreviationType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0007/_3/CantonFlAbbreviationType.java
@@ -1,49 +1,50 @@
 
 package ch.ech.xmlns.ech_0007._3;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for cantonFlAbbreviationType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="cantonFlAbbreviationType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}token"&gt;
- *     &lt;maxLength value="2"/&gt;
- *     &lt;enumeration value="ZH"/&gt;
- *     &lt;enumeration value="BE"/&gt;
- *     &lt;enumeration value="LU"/&gt;
- *     &lt;enumeration value="UR"/&gt;
- *     &lt;enumeration value="SZ"/&gt;
- *     &lt;enumeration value="OW"/&gt;
- *     &lt;enumeration value="NW"/&gt;
- *     &lt;enumeration value="GL"/&gt;
- *     &lt;enumeration value="ZG"/&gt;
- *     &lt;enumeration value="FR"/&gt;
- *     &lt;enumeration value="SO"/&gt;
- *     &lt;enumeration value="BS"/&gt;
- *     &lt;enumeration value="BL"/&gt;
- *     &lt;enumeration value="SH"/&gt;
- *     &lt;enumeration value="AR"/&gt;
- *     &lt;enumeration value="AI"/&gt;
- *     &lt;enumeration value="SG"/&gt;
- *     &lt;enumeration value="GR"/&gt;
- *     &lt;enumeration value="AG"/&gt;
- *     &lt;enumeration value="TG"/&gt;
- *     &lt;enumeration value="TI"/&gt;
- *     &lt;enumeration value="VD"/&gt;
- *     &lt;enumeration value="VS"/&gt;
- *     &lt;enumeration value="NE"/&gt;
- *     &lt;enumeration value="GE"/&gt;
- *     &lt;enumeration value="JU"/&gt;
- *     &lt;enumeration value="FL"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for cantonFlAbbreviationType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="cantonFlAbbreviationType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}token">
+ *     <maxLength value="2"/>
+ *     <enumeration value="ZH"/>
+ *     <enumeration value="BE"/>
+ *     <enumeration value="LU"/>
+ *     <enumeration value="UR"/>
+ *     <enumeration value="SZ"/>
+ *     <enumeration value="OW"/>
+ *     <enumeration value="NW"/>
+ *     <enumeration value="GL"/>
+ *     <enumeration value="ZG"/>
+ *     <enumeration value="FR"/>
+ *     <enumeration value="SO"/>
+ *     <enumeration value="BS"/>
+ *     <enumeration value="BL"/>
+ *     <enumeration value="SH"/>
+ *     <enumeration value="AR"/>
+ *     <enumeration value="AI"/>
+ *     <enumeration value="SG"/>
+ *     <enumeration value="GR"/>
+ *     <enumeration value="AG"/>
+ *     <enumeration value="TG"/>
+ *     <enumeration value="TI"/>
+ *     <enumeration value="VD"/>
+ *     <enumeration value="VS"/>
+ *     <enumeration value="NE"/>
+ *     <enumeration value="GE"/>
+ *     <enumeration value="JU"/>
+ *     <enumeration value="FL"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "cantonFlAbbreviationType")

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0007/_3/MunicipalityRoot.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0007/_3/MunicipalityRoot.java
@@ -1,29 +1,29 @@
 
 package ch.ech.xmlns.ech_0007._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for anonymous complex type.
+ * <p>Java class for anonymous complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;choice&gt;
- *         &lt;element name="swissMunicipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/&gt;
- *         &lt;element name="swissAndFlMunicipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissAndFlMunicipalityType"/&gt;
- *       &lt;/choice&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType>
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <choice>
+ *         <element name="swissMunicipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/>
+ *         <element name="swissAndFlMunicipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissAndFlMunicipalityType"/>
+ *       </choice>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0007/_3/ObjectFactory.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0007/_3/ObjectFactory.java
@@ -1,14 +1,14 @@
 
 package ch.ech.xmlns.ech_0007._3;
 
-import javax.xml.bind.annotation.XmlRegistry;
+import jakarta.xml.bind.annotation.XmlRegistry;
 
 
 /**
  * This object contains factory methods for each 
  * Java content interface and Java element interface 
  * generated in the ch.ech.xmlns.ech_0007._3 package. 
- * <p>An ObjectFactory allows you to programatically 
+ * <p>An ObjectFactory allows you to programmatically 
  * construct new instances of the Java representation 
  * for XML content. The Java representation of XML 
  * content can consist of schema derived interfaces 
@@ -32,6 +32,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link MunicipalityRoot }
      * 
+     * @return
+     *     the new instance of {@link MunicipalityRoot }
      */
     public MunicipalityRoot createMunicipalityRoot() {
         return new MunicipalityRoot();
@@ -40,6 +42,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link SwissMunicipalityType }
      * 
+     * @return
+     *     the new instance of {@link SwissMunicipalityType }
      */
     public SwissMunicipalityType createSwissMunicipalityType() {
         return new SwissMunicipalityType();
@@ -48,6 +52,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link SwissAndFlMunicipalityType }
      * 
+     * @return
+     *     the new instance of {@link SwissAndFlMunicipalityType }
      */
     public SwissAndFlMunicipalityType createSwissAndFlMunicipalityType() {
         return new SwissAndFlMunicipalityType();

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0007/_3/SwissAndFlMunicipalityType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0007/_3/SwissAndFlMunicipalityType.java
@@ -1,34 +1,34 @@
 
 package ch.ech.xmlns.ech_0007._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 
 /**
- * <p>Java class for swissAndFlMunicipalityType complex type.
+ * <p>Java class for swissAndFlMunicipalityType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="swissAndFlMunicipalityType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="municipalityId" type="{http://www.ech.ch/xmlns/eCH-0007/3}municipalityIdType"/&gt;
- *         &lt;element name="municipalityName" type="{http://www.ech.ch/xmlns/eCH-0007/3}municipalityNameType"/&gt;
- *         &lt;element name="cantonFlAbbreviation" type="{http://www.ech.ch/xmlns/eCH-0007/3}cantonFlAbbreviationType"/&gt;
- *         &lt;element name="historyMunicipialityId" type="{http://www.ech.ch/xmlns/eCH-0007/3}historyMunicipalityId" minOccurs="0"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="swissAndFlMunicipalityType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="municipalityId" type="{http://www.ech.ch/xmlns/eCH-0007/3}municipalityIdType"/>
+ *         <element name="municipalityName" type="{http://www.ech.ch/xmlns/eCH-0007/3}municipalityNameType"/>
+ *         <element name="cantonFlAbbreviation" type="{http://www.ech.ch/xmlns/eCH-0007/3}cantonFlAbbreviationType"/>
+ *         <element name="historyMunicipialityId" type="{http://www.ech.ch/xmlns/eCH-0007/3}historyMunicipalityId" minOccurs="0"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0007/_3/SwissMunicipalityType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0007/_3/SwissMunicipalityType.java
@@ -1,34 +1,34 @@
 
 package ch.ech.xmlns.ech_0007._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 
 /**
- * <p>Java class for swissMunicipalityType complex type.
+ * <p>Java class for swissMunicipalityType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="swissMunicipalityType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="municipalityId" type="{http://www.ech.ch/xmlns/eCH-0007/3}municipalityIdType" minOccurs="0"/&gt;
- *         &lt;element name="municipalityName" type="{http://www.ech.ch/xmlns/eCH-0007/3}municipalityNameType"/&gt;
- *         &lt;element name="cantonAbbreviation" type="{http://www.ech.ch/xmlns/eCH-0007/3}cantonAbbreviationType" minOccurs="0"/&gt;
- *         &lt;element name="historyMunicipialityId" type="{http://www.ech.ch/xmlns/eCH-0007/3}historyMunicipalityId" minOccurs="0"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="swissMunicipalityType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="municipalityId" type="{http://www.ech.ch/xmlns/eCH-0007/3}municipalityIdType" minOccurs="0"/>
+ *         <element name="municipalityName" type="{http://www.ech.ch/xmlns/eCH-0007/3}municipalityNameType"/>
+ *         <element name="cantonAbbreviation" type="{http://www.ech.ch/xmlns/eCH-0007/3}cantonAbbreviationType" minOccurs="0"/>
+ *         <element name="historyMunicipialityId" type="{http://www.ech.ch/xmlns/eCH-0007/3}historyMunicipalityId" minOccurs="0"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0007/_3/package-info.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0007/_3/package-info.java
@@ -1,2 +1,2 @@
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.ech.ch/xmlns/eCH-0007/3", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://www.ech.ch/xmlns/eCH-0007/3", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package ch.ech.xmlns.ech_0007._3;

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0008/_2/CountryRoot.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0008/_2/CountryRoot.java
@@ -1,29 +1,29 @@
 
 package ch.ech.xmlns.ech_0008._2;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for anonymous complex type.
+ * <p>Java class for anonymous complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="country" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryType"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType>
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="country" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryType"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0008/_2/CountryShortType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0008/_2/CountryShortType.java
@@ -1,31 +1,31 @@
 
 package ch.ech.xmlns.ech_0008._2;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 
 /**
- * <p>Java class for countryShortType complex type.
+ * <p>Java class for countryShortType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="countryShortType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="countryNameShort" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryNameShortType"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="countryShortType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="countryNameShort" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryNameShortType"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0008/_2/CountryType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0008/_2/CountryType.java
@@ -1,33 +1,33 @@
 
 package ch.ech.xmlns.ech_0008._2;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 
 /**
- * <p>Java class for countryType complex type.
+ * <p>Java class for countryType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="countryType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="countryId" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryIdType" minOccurs="0"/&gt;
- *         &lt;element name="countryIdISO2" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryIdISO2Type" minOccurs="0"/&gt;
- *         &lt;element name="countryNameShort" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryNameShortType"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="countryType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="countryId" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryIdType" minOccurs="0"/>
+ *         <element name="countryIdISO2" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryIdISO2Type" minOccurs="0"/>
+ *         <element name="countryNameShort" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryNameShortType"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0008/_2/LanguageType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0008/_2/LanguageType.java
@@ -1,27 +1,28 @@
 
 package ch.ech.xmlns.ech_0008._2;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for languageType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="languageType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}token"&gt;
- *     &lt;length value="2"/&gt;
- *     &lt;enumeration value="fr"/&gt;
- *     &lt;enumeration value="it"/&gt;
- *     &lt;enumeration value="dt"/&gt;
- *     &lt;enumeration value="en"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for languageType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="languageType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}token">
+ *     <length value="2"/>
+ *     <enumeration value="fr"/>
+ *     <enumeration value="it"/>
+ *     <enumeration value="dt"/>
+ *     <enumeration value="en"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "languageType")
@@ -42,10 +43,26 @@ public enum LanguageType {
         value = v;
     }
 
+    /**
+     * Gets the value associated to the enum constant.
+     * 
+     * @return
+     *     The value linked to the enum.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Gets the enum associated to the value passed as parameter.
+     * 
+     * @param v
+     *     The value to get the enum from.
+     * @return
+     *     The enum which corresponds to the value, if it exists.
+     * @throws IllegalArgumentException
+     *     If no value matches in the enum declaration.
+     */
     public static LanguageType fromValue(String v) {
         for (LanguageType c: LanguageType.values()) {
             if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0008/_2/ObjectFactory.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0008/_2/ObjectFactory.java
@@ -1,14 +1,14 @@
 
 package ch.ech.xmlns.ech_0008._2;
 
-import javax.xml.bind.annotation.XmlRegistry;
+import jakarta.xml.bind.annotation.XmlRegistry;
 
 
 /**
  * This object contains factory methods for each 
  * Java content interface and Java element interface 
  * generated in the ch.ech.xmlns.ech_0008._2 package. 
- * <p>An ObjectFactory allows you to programatically 
+ * <p>An ObjectFactory allows you to programmatically 
  * construct new instances of the Java representation 
  * for XML content. The Java representation of XML 
  * content can consist of schema derived interfaces 
@@ -32,6 +32,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link CountryRoot }
      * 
+     * @return
+     *     the new instance of {@link CountryRoot }
      */
     public CountryRoot createCountryRoot() {
         return new CountryRoot();
@@ -40,6 +42,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link CountryType }
      * 
+     * @return
+     *     the new instance of {@link CountryType }
      */
     public CountryType createCountryType() {
         return new CountryType();
@@ -48,6 +52,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link CountryShortType }
      * 
+     * @return
+     *     the new instance of {@link CountryShortType }
      */
     public CountryShortType createCountryShortType() {
         return new CountryShortType();

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0008/_2/package-info.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0008/_2/package-info.java
@@ -1,2 +1,2 @@
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.ech.ch/xmlns/eCH-0008/2", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://www.ech.ch/xmlns/eCH-0008/2", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package ch.ech.xmlns.ech_0008._2;

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/AddressInformationType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/AddressInformationType.java
@@ -1,52 +1,52 @@
 
 package ch.ech.xmlns.ech_0010._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 
 /**
- * <p>Java class for addressInformationType complex type.
+ * <p>Java class for addressInformationType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="addressInformationType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="addressLine1" type="{http://www.ech.ch/xmlns/eCH-0010/3}addressLineType" minOccurs="0"/&gt;
- *         &lt;element name="addressLine2" type="{http://www.ech.ch/xmlns/eCH-0010/3}addressLineType" minOccurs="0"/&gt;
- *         &lt;sequence minOccurs="0"&gt;
- *           &lt;element name="street" type="{http://www.ech.ch/xmlns/eCH-0010/3}streetType"/&gt;
- *           &lt;element name="houseNumber" type="{http://www.ech.ch/xmlns/eCH-0010/3}houseNumberType" minOccurs="0"/&gt;
- *           &lt;element name="dwellingNumber" type="{http://www.ech.ch/xmlns/eCH-0010/3}dwellingNumberType" minOccurs="0"/&gt;
- *         &lt;/sequence&gt;
- *         &lt;sequence minOccurs="0"&gt;
- *           &lt;element name="postOfficeBoxNumber" type="{http://www.ech.ch/xmlns/eCH-0010/3}postOfficeBoxNumberType" minOccurs="0"/&gt;
- *           &lt;element name="postOfficeBoxText" type="{http://www.ech.ch/xmlns/eCH-0010/3}postOfficeBoxTextType"/&gt;
- *         &lt;/sequence&gt;
- *         &lt;element name="locality" type="{http://www.ech.ch/xmlns/eCH-0010/3}localityType" minOccurs="0"/&gt;
- *         &lt;element name="town" type="{http://www.ech.ch/xmlns/eCH-0010/3}townType"/&gt;
- *         &lt;choice&gt;
- *           &lt;sequence&gt;
- *             &lt;element name="swissZipCode" type="{http://www.ech.ch/xmlns/eCH-0010/3}swissZipCodeType"/&gt;
- *             &lt;element name="swissZipCodeAddOn" type="{http://www.ech.ch/xmlns/eCH-0010/3}swissZipCodeAddOnType" minOccurs="0"/&gt;
- *             &lt;element name="swissZipCodeId" type="{http://www.ech.ch/xmlns/eCH-0010/3}swissZipCodeIdType" minOccurs="0"/&gt;
- *           &lt;/sequence&gt;
- *           &lt;element name="foreignZipCode" type="{http://www.ech.ch/xmlns/eCH-0010/3}foreignZipCodeType"/&gt;
- *         &lt;/choice&gt;
- *         &lt;element name="country" type="{http://www.ech.ch/xmlns/eCH-0010/3}countryType"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="addressInformationType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="addressLine1" type="{http://www.ech.ch/xmlns/eCH-0010/3}addressLineType" minOccurs="0"/>
+ *         <element name="addressLine2" type="{http://www.ech.ch/xmlns/eCH-0010/3}addressLineType" minOccurs="0"/>
+ *         <sequence minOccurs="0">
+ *           <element name="street" type="{http://www.ech.ch/xmlns/eCH-0010/3}streetType"/>
+ *           <element name="houseNumber" type="{http://www.ech.ch/xmlns/eCH-0010/3}houseNumberType" minOccurs="0"/>
+ *           <element name="dwellingNumber" type="{http://www.ech.ch/xmlns/eCH-0010/3}dwellingNumberType" minOccurs="0"/>
+ *         </sequence>
+ *         <sequence minOccurs="0">
+ *           <element name="postOfficeBoxNumber" type="{http://www.ech.ch/xmlns/eCH-0010/3}postOfficeBoxNumberType" minOccurs="0"/>
+ *           <element name="postOfficeBoxText" type="{http://www.ech.ch/xmlns/eCH-0010/3}postOfficeBoxTextType"/>
+ *         </sequence>
+ *         <element name="locality" type="{http://www.ech.ch/xmlns/eCH-0010/3}localityType" minOccurs="0"/>
+ *         <element name="town" type="{http://www.ech.ch/xmlns/eCH-0010/3}townType"/>
+ *         <choice>
+ *           <sequence>
+ *             <element name="swissZipCode" type="{http://www.ech.ch/xmlns/eCH-0010/3}swissZipCodeType"/>
+ *             <element name="swissZipCodeAddOn" type="{http://www.ech.ch/xmlns/eCH-0010/3}swissZipCodeAddOnType" minOccurs="0"/>
+ *             <element name="swissZipCodeId" type="{http://www.ech.ch/xmlns/eCH-0010/3}swissZipCodeIdType" minOccurs="0"/>
+ *           </sequence>
+ *           <element name="foreignZipCode" type="{http://www.ech.ch/xmlns/eCH-0010/3}foreignZipCodeType"/>
+ *         </choice>
+ *         <element name="country" type="{http://www.ech.ch/xmlns/eCH-0010/3}countryType"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/MailAddressType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/MailAddressType.java
@@ -1,32 +1,32 @@
 
 package ch.ech.xmlns.ech_0010._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for mailAddressType complex type.
+ * <p>Java class for mailAddressType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="mailAddressType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;choice&gt;
- *           &lt;element name="organisation" type="{http://www.ech.ch/xmlns/eCH-0010/3}organisationMailAddressInfoType"/&gt;
- *           &lt;element name="person" type="{http://www.ech.ch/xmlns/eCH-0010/3}personMailAddressInfoType"/&gt;
- *         &lt;/choice&gt;
- *         &lt;element name="addressInformation" type="{http://www.ech.ch/xmlns/eCH-0010/3}addressInformationType"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="mailAddressType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <choice>
+ *           <element name="organisation" type="{http://www.ech.ch/xmlns/eCH-0010/3}organisationMailAddressInfoType"/>
+ *           <element name="person" type="{http://www.ech.ch/xmlns/eCH-0010/3}personMailAddressInfoType"/>
+ *         </choice>
+ *         <element name="addressInformation" type="{http://www.ech.ch/xmlns/eCH-0010/3}addressInformationType"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/MrMrsType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/MrMrsType.java
@@ -1,25 +1,26 @@
 
 package ch.ech.xmlns.ech_0010._3;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for mrMrsType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="mrMrsType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}token"&gt;
- *     &lt;enumeration value="1"/&gt;
- *     &lt;enumeration value="2"/&gt;
- *     &lt;enumeration value="3"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for mrMrsType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="mrMrsType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}token">
+ *     <enumeration value="1"/>
+ *     <enumeration value="2"/>
+ *     <enumeration value="3"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "mrMrsType")
@@ -38,10 +39,26 @@ public enum MrMrsType {
         value = v;
     }
 
+    /**
+     * Gets the value associated to the enum constant.
+     * 
+     * @return
+     *     The value linked to the enum.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Gets the enum associated to the value passed as parameter.
+     * 
+     * @param v
+     *     The value to get the enum from.
+     * @return
+     *     The enum which corresponds to the value, if it exists.
+     * @throws IllegalArgumentException
+     *     If no value matches in the enum declaration.
+     */
     public static MrMrsType fromValue(String v) {
         for (MrMrsType c: MrMrsType.values()) {
             if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/ObjectFactory.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/ObjectFactory.java
@@ -1,17 +1,17 @@
 
 package ch.ech.xmlns.ech_0010._3;
 
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.annotation.XmlElementDecl;
-import javax.xml.bind.annotation.XmlRegistry;
 import javax.xml.namespace.QName;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.annotation.XmlElementDecl;
+import jakarta.xml.bind.annotation.XmlRegistry;
 
 
 /**
  * This object contains factory methods for each 
  * Java content interface and Java element interface 
  * generated in the ch.ech.xmlns.ech_0010._3 package. 
- * <p>An ObjectFactory allows you to programatically 
+ * <p>An ObjectFactory allows you to programmatically 
  * construct new instances of the Java representation 
  * for XML content. The Java representation of XML 
  * content can consist of schema derived interfaces 
@@ -24,9 +24,9 @@ import javax.xml.namespace.QName;
 @XmlRegistry
 public class ObjectFactory {
 
-    private final static QName _PersonMailAddress_QNAME = new QName("http://www.ech.ch/xmlns/eCH-0010/3", "personMailAddress");
-    private final static QName _OrganisationMailAdress_QNAME = new QName("http://www.ech.ch/xmlns/eCH-0010/3", "organisationMailAdress");
-    private final static QName _MailAddress_QNAME = new QName("http://www.ech.ch/xmlns/eCH-0010/3", "mailAddress");
+    private static final QName _PersonMailAddress_QNAME = new QName("http://www.ech.ch/xmlns/eCH-0010/3", "personMailAddress");
+    private static final QName _OrganisationMailAdress_QNAME = new QName("http://www.ech.ch/xmlns/eCH-0010/3", "organisationMailAdress");
+    private static final QName _MailAddress_QNAME = new QName("http://www.ech.ch/xmlns/eCH-0010/3", "mailAddress");
 
     /**
      * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: ch.ech.xmlns.ech_0010._3
@@ -38,6 +38,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link PersonMailAddressType }
      * 
+     * @return
+     *     the new instance of {@link PersonMailAddressType }
      */
     public PersonMailAddressType createPersonMailAddressType() {
         return new PersonMailAddressType();
@@ -46,6 +48,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link OrganisationMailAddressType }
      * 
+     * @return
+     *     the new instance of {@link OrganisationMailAddressType }
      */
     public OrganisationMailAddressType createOrganisationMailAddressType() {
         return new OrganisationMailAddressType();
@@ -54,6 +58,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link MailAddressType }
      * 
+     * @return
+     *     the new instance of {@link MailAddressType }
      */
     public MailAddressType createMailAddressType() {
         return new MailAddressType();
@@ -62,6 +68,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link PersonMailAddressInfoType }
      * 
+     * @return
+     *     the new instance of {@link PersonMailAddressInfoType }
      */
     public PersonMailAddressInfoType createPersonMailAddressInfoType() {
         return new PersonMailAddressInfoType();
@@ -70,6 +78,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link OrganisationMailAddressInfoType }
      * 
+     * @return
+     *     the new instance of {@link OrganisationMailAddressInfoType }
      */
     public OrganisationMailAddressInfoType createOrganisationMailAddressInfoType() {
         return new OrganisationMailAddressInfoType();
@@ -78,6 +88,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link AddressInformationType }
      * 
+     * @return
+     *     the new instance of {@link AddressInformationType }
      */
     public AddressInformationType createAddressInformationType() {
         return new AddressInformationType();
@@ -86,36 +98,50 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link SwissAddressInformationType }
      * 
+     * @return
+     *     the new instance of {@link SwissAddressInformationType }
      */
     public SwissAddressInformationType createSwissAddressInformationType() {
         return new SwissAddressInformationType();
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link PersonMailAddressType }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link PersonMailAddressType }{@code >}
      * 
+     * @param value
+     *     Java instance representing xml element's value.
+     * @return
+     *     the new instance of {@link JAXBElement }{@code <}{@link PersonMailAddressType }{@code >}
      */
     @XmlElementDecl(namespace = "http://www.ech.ch/xmlns/eCH-0010/3", name = "personMailAddress")
     public JAXBElement<PersonMailAddressType> createPersonMailAddress(PersonMailAddressType value) {
-        return new JAXBElement<PersonMailAddressType>(_PersonMailAddress_QNAME, PersonMailAddressType.class, null, value);
+        return new JAXBElement<>(_PersonMailAddress_QNAME, PersonMailAddressType.class, null, value);
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link OrganisationMailAddressType }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link OrganisationMailAddressType }{@code >}
      * 
+     * @param value
+     *     Java instance representing xml element's value.
+     * @return
+     *     the new instance of {@link JAXBElement }{@code <}{@link OrganisationMailAddressType }{@code >}
      */
     @XmlElementDecl(namespace = "http://www.ech.ch/xmlns/eCH-0010/3", name = "organisationMailAdress")
     public JAXBElement<OrganisationMailAddressType> createOrganisationMailAdress(OrganisationMailAddressType value) {
-        return new JAXBElement<OrganisationMailAddressType>(_OrganisationMailAdress_QNAME, OrganisationMailAddressType.class, null, value);
+        return new JAXBElement<>(_OrganisationMailAdress_QNAME, OrganisationMailAddressType.class, null, value);
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link MailAddressType }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link MailAddressType }{@code >}
      * 
+     * @param value
+     *     Java instance representing xml element's value.
+     * @return
+     *     the new instance of {@link JAXBElement }{@code <}{@link MailAddressType }{@code >}
      */
     @XmlElementDecl(namespace = "http://www.ech.ch/xmlns/eCH-0010/3", name = "mailAddress")
     public JAXBElement<MailAddressType> createMailAddress(MailAddressType value) {
-        return new JAXBElement<MailAddressType>(_MailAddress_QNAME, MailAddressType.class, null, value);
+        return new JAXBElement<>(_MailAddress_QNAME, MailAddressType.class, null, value);
     }
 
 }

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/OrganisationMailAddressInfoType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/OrganisationMailAddressInfoType.java
@@ -1,36 +1,36 @@
 
 package ch.ech.xmlns.ech_0010._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 
 /**
- * <p>Java class for organisationMailAddressInfoType complex type.
+ * <p>Java class for organisationMailAddressInfoType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="organisationMailAddressInfoType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="organisationName" type="{http://www.ech.ch/xmlns/eCH-0010/3}organisationNameType"/&gt;
- *         &lt;element name="organisationNameAddOn1" type="{http://www.ech.ch/xmlns/eCH-0010/3}organisationNameType" minOccurs="0"/&gt;
- *         &lt;element name="organisationNameAddOn2" type="{http://www.ech.ch/xmlns/eCH-0010/3}organisationNameType" minOccurs="0"/&gt;
- *         &lt;element name="title" type="{http://www.ech.ch/xmlns/eCH-0010/3}titleType" minOccurs="0"/&gt;
- *         &lt;element name="firstName" type="{http://www.ech.ch/xmlns/eCH-0010/3}firstNameType" minOccurs="0"/&gt;
- *         &lt;element name="lastName" type="{http://www.ech.ch/xmlns/eCH-0010/3}lastNameType" minOccurs="0"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="organisationMailAddressInfoType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="organisationName" type="{http://www.ech.ch/xmlns/eCH-0010/3}organisationNameType"/>
+ *         <element name="organisationNameAddOn1" type="{http://www.ech.ch/xmlns/eCH-0010/3}organisationNameType" minOccurs="0"/>
+ *         <element name="organisationNameAddOn2" type="{http://www.ech.ch/xmlns/eCH-0010/3}organisationNameType" minOccurs="0"/>
+ *         <element name="title" type="{http://www.ech.ch/xmlns/eCH-0010/3}titleType" minOccurs="0"/>
+ *         <element name="firstName" type="{http://www.ech.ch/xmlns/eCH-0010/3}firstNameType" minOccurs="0"/>
+ *         <element name="lastName" type="{http://www.ech.ch/xmlns/eCH-0010/3}lastNameType" minOccurs="0"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/OrganisationMailAddressType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/OrganisationMailAddressType.java
@@ -1,29 +1,29 @@
 
 package ch.ech.xmlns.ech_0010._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for organisationMailAddressType complex type.
+ * <p>Java class for organisationMailAddressType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="organisationMailAddressType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="organisation" type="{http://www.ech.ch/xmlns/eCH-0010/3}organisationMailAddressInfoType"/&gt;
- *         &lt;element name="addressInformation" type="{http://www.ech.ch/xmlns/eCH-0010/3}addressInformationType"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="organisationMailAddressType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="organisation" type="{http://www.ech.ch/xmlns/eCH-0010/3}organisationMailAddressInfoType"/>
+ *         <element name="addressInformation" type="{http://www.ech.ch/xmlns/eCH-0010/3}addressInformationType"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/PersonMailAddressInfoType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/PersonMailAddressInfoType.java
@@ -1,34 +1,34 @@
 
 package ch.ech.xmlns.ech_0010._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 
 /**
- * <p>Java class for personMailAddressInfoType complex type.
+ * <p>Java class for personMailAddressInfoType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="personMailAddressInfoType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="mrMrs" type="{http://www.ech.ch/xmlns/eCH-0010/3}mrMrsType" minOccurs="0"/&gt;
- *         &lt;element name="title" type="{http://www.ech.ch/xmlns/eCH-0010/3}titleType" minOccurs="0"/&gt;
- *         &lt;element name="firstName" type="{http://www.ech.ch/xmlns/eCH-0010/3}firstNameType" minOccurs="0"/&gt;
- *         &lt;element name="lastName" type="{http://www.ech.ch/xmlns/eCH-0010/3}lastNameType"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="personMailAddressInfoType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="mrMrs" type="{http://www.ech.ch/xmlns/eCH-0010/3}mrMrsType" minOccurs="0"/>
+ *         <element name="title" type="{http://www.ech.ch/xmlns/eCH-0010/3}titleType" minOccurs="0"/>
+ *         <element name="firstName" type="{http://www.ech.ch/xmlns/eCH-0010/3}firstNameType" minOccurs="0"/>
+ *         <element name="lastName" type="{http://www.ech.ch/xmlns/eCH-0010/3}lastNameType"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/PersonMailAddressType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/PersonMailAddressType.java
@@ -1,29 +1,29 @@
 
 package ch.ech.xmlns.ech_0010._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for personMailAddressType complex type.
+ * <p>Java class for personMailAddressType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="personMailAddressType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="person" type="{http://www.ech.ch/xmlns/eCH-0010/3}personMailAddressInfoType"/&gt;
- *         &lt;element name="addressInformation" type="{http://www.ech.ch/xmlns/eCH-0010/3}addressInformationType"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="personMailAddressType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="person" type="{http://www.ech.ch/xmlns/eCH-0010/3}personMailAddressInfoType"/>
+ *         <element name="addressInformation" type="{http://www.ech.ch/xmlns/eCH-0010/3}addressInformationType"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/SwissAddressInformationType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/SwissAddressInformationType.java
@@ -1,50 +1,50 @@
 
 package ch.ech.xmlns.ech_0010._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 
 /**
- * <p>Java class for swissAddressInformationType complex type.
+ * <p>Java class for swissAddressInformationType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="swissAddressInformationType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="addressLine1" type="{http://www.ech.ch/xmlns/eCH-0010/3}addressLineType" minOccurs="0"/&gt;
- *         &lt;element name="addressLine2" type="{http://www.ech.ch/xmlns/eCH-0010/3}addressLineType" minOccurs="0"/&gt;
- *         &lt;sequence minOccurs="0"&gt;
- *           &lt;element name="street" type="{http://www.ech.ch/xmlns/eCH-0010/3}streetType"/&gt;
- *           &lt;element name="houseNumber" type="{http://www.ech.ch/xmlns/eCH-0010/3}houseNumberType" minOccurs="0"/&gt;
- *           &lt;element name="dwellingNumber" type="{http://www.ech.ch/xmlns/eCH-0010/3}dwellingNumberType" minOccurs="0"/&gt;
- *         &lt;/sequence&gt;
- *         &lt;element name="town" type="{http://www.ech.ch/xmlns/eCH-0010/3}townType"/&gt;
- *         &lt;sequence&gt;
- *           &lt;element name="swissZipCode" type="{http://www.ech.ch/xmlns/eCH-0010/3}swissZipCodeType"/&gt;
- *           &lt;element name="swissZipCodeAddOn" type="{http://www.ech.ch/xmlns/eCH-0010/3}swissZipCodeAddOnType" minOccurs="0"/&gt;
- *           &lt;element name="swissZipCodeId" type="{http://www.ech.ch/xmlns/eCH-0010/3}swissZipCodeIdType" minOccurs="0"/&gt;
- *         &lt;/sequence&gt;
- *         &lt;element name="country"&gt;
- *           &lt;simpleType&gt;
- *             &lt;restriction base="{http://www.ech.ch/xmlns/eCH-0010/3}countryType"&gt;
- *               &lt;enumeration value="CH"/&gt;
- *             &lt;/restriction&gt;
- *           &lt;/simpleType&gt;
- *         &lt;/element&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="swissAddressInformationType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="addressLine1" type="{http://www.ech.ch/xmlns/eCH-0010/3}addressLineType" minOccurs="0"/>
+ *         <element name="addressLine2" type="{http://www.ech.ch/xmlns/eCH-0010/3}addressLineType" minOccurs="0"/>
+ *         <sequence minOccurs="0">
+ *           <element name="street" type="{http://www.ech.ch/xmlns/eCH-0010/3}streetType"/>
+ *           <element name="houseNumber" type="{http://www.ech.ch/xmlns/eCH-0010/3}houseNumberType" minOccurs="0"/>
+ *           <element name="dwellingNumber" type="{http://www.ech.ch/xmlns/eCH-0010/3}dwellingNumberType" minOccurs="0"/>
+ *         </sequence>
+ *         <element name="town" type="{http://www.ech.ch/xmlns/eCH-0010/3}townType"/>
+ *         <sequence>
+ *           <element name="swissZipCode" type="{http://www.ech.ch/xmlns/eCH-0010/3}swissZipCodeType"/>
+ *           <element name="swissZipCodeAddOn" type="{http://www.ech.ch/xmlns/eCH-0010/3}swissZipCodeAddOnType" minOccurs="0"/>
+ *           <element name="swissZipCodeId" type="{http://www.ech.ch/xmlns/eCH-0010/3}swissZipCodeIdType" minOccurs="0"/>
+ *         </sequence>
+ *         <element name="country">
+ *           <simpleType>
+ *             <restriction base="{http://www.ech.ch/xmlns/eCH-0010/3}countryType">
+ *               <enumeration value="CH"/>
+ *             </restriction>
+ *           </simpleType>
+ *         </element>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/package-info.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0010/_3/package-info.java
@@ -1,2 +1,2 @@
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.ech.ch/xmlns/eCH-0010/3", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://www.ech.ch/xmlns/eCH-0010/3", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package ch.ech.xmlns.ech_0010._3;

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/AnyPersonType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/AnyPersonType.java
@@ -3,56 +3,56 @@ package ch.ech.xmlns.ech_0011._3;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import javax.xml.datatype.XMLGregorianCalendar;
 import ch.ech.xmlns.ech_0006._2.ResidencePermitType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 
 /**
- * <p>Java class for anyPersonType complex type.
+ * <p>Java class for anyPersonType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="anyPersonType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;choice&gt;
- *         &lt;element name="swiss"&gt;
- *           &lt;complexType&gt;
- *             &lt;complexContent&gt;
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *                 &lt;sequence&gt;
- *                   &lt;element name="placeOfOrigin" type="{http://www.ech.ch/xmlns/eCH-0011/3}placeOfOriginType" maxOccurs="unbounded"/&gt;
- *                 &lt;/sequence&gt;
- *               &lt;/restriction&gt;
- *             &lt;/complexContent&gt;
- *           &lt;/complexType&gt;
- *         &lt;/element&gt;
- *         &lt;element name="foreigner"&gt;
- *           &lt;complexType&gt;
- *             &lt;complexContent&gt;
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *                 &lt;sequence&gt;
- *                   &lt;element name="residencePermit" type="{http://www.ech.ch/xmlns/eCH-0006/2}residencePermitType"/&gt;
- *                   &lt;element name="residencePermitTill" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/&gt;
- *                   &lt;element name="nameOnPassport" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/&gt;
- *                 &lt;/sequence&gt;
- *               &lt;/restriction&gt;
- *             &lt;/complexContent&gt;
- *           &lt;/complexType&gt;
- *         &lt;/element&gt;
- *       &lt;/choice&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="anyPersonType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <choice>
+ *         <element name="swiss">
+ *           <complexType>
+ *             <complexContent>
+ *               <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *                 <sequence>
+ *                   <element name="placeOfOrigin" type="{http://www.ech.ch/xmlns/eCH-0011/3}placeOfOriginType" maxOccurs="unbounded"/>
+ *                 </sequence>
+ *               </restriction>
+ *             </complexContent>
+ *           </complexType>
+ *         </element>
+ *         <element name="foreigner">
+ *           <complexType>
+ *             <complexContent>
+ *               <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *                 <sequence>
+ *                   <element name="residencePermit" type="{http://www.ech.ch/xmlns/eCH-0006/2}residencePermitType"/>
+ *                   <element name="residencePermitTill" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/>
+ *                   <element name="nameOnPassport" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/>
+ *                 </sequence>
+ *               </restriction>
+ *             </complexContent>
+ *           </complexType>
+ *         </element>
+ *       </choice>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */
@@ -138,23 +138,23 @@ public class AnyPersonType {
 
 
     /**
-     * <p>Java class for anonymous complex type.
+     * <p>Java class for anonymous complex type</p>.
      * 
-     * <p>The following schema fragment specifies the expected content contained within this class.
+     * <p>The following schema fragment specifies the expected content contained within this class.</p>
      * 
-     * <pre>
-     * &lt;complexType&gt;
-     *   &lt;complexContent&gt;
-     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
-     *       &lt;sequence&gt;
-     *         &lt;element name="residencePermit" type="{http://www.ech.ch/xmlns/eCH-0006/2}residencePermitType"/&gt;
-     *         &lt;element name="residencePermitTill" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/&gt;
-     *         &lt;element name="nameOnPassport" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/&gt;
-     *       &lt;/sequence&gt;
-     *     &lt;/restriction&gt;
-     *   &lt;/complexContent&gt;
-     * &lt;/complexType&gt;
-     * </pre>
+     * <pre>{@code
+     * <complexType>
+     *   <complexContent>
+     *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+     *       <sequence>
+     *         <element name="residencePermit" type="{http://www.ech.ch/xmlns/eCH-0006/2}residencePermitType"/>
+     *         <element name="residencePermitTill" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/>
+     *         <element name="nameOnPassport" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/>
+     *       </sequence>
+     *     </restriction>
+     *   </complexContent>
+     * </complexType>
+     * }</pre>
      * 
      * 
      */
@@ -263,21 +263,21 @@ public class AnyPersonType {
 
 
     /**
-     * <p>Java class for anonymous complex type.
+     * <p>Java class for anonymous complex type</p>.
      * 
-     * <p>The following schema fragment specifies the expected content contained within this class.
+     * <p>The following schema fragment specifies the expected content contained within this class.</p>
      * 
-     * <pre>
-     * &lt;complexType&gt;
-     *   &lt;complexContent&gt;
-     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
-     *       &lt;sequence&gt;
-     *         &lt;element name="placeOfOrigin" type="{http://www.ech.ch/xmlns/eCH-0011/3}placeOfOriginType" maxOccurs="unbounded"/&gt;
-     *       &lt;/sequence&gt;
-     *     &lt;/restriction&gt;
-     *   &lt;/complexContent&gt;
-     * &lt;/complexType&gt;
-     * </pre>
+     * <pre>{@code
+     * <complexType>
+     *   <complexContent>
+     *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+     *       <sequence>
+     *         <element name="placeOfOrigin" type="{http://www.ech.ch/xmlns/eCH-0011/3}placeOfOriginType" maxOccurs="unbounded"/>
+     *       </sequence>
+     *     </restriction>
+     *   </complexContent>
+     * </complexType>
+     * }</pre>
      * 
      * 
      */
@@ -293,28 +293,31 @@ public class AnyPersonType {
         /**
          * Gets the value of the placeOfOrigin property.
          * 
-         * <p>
-         * This accessor method returns a reference to the live list,
+         * <p>This accessor method returns a reference to the live list,
          * not a snapshot. Therefore any modification you make to the
          * returned list will be present inside the JAXB object.
-         * This is why there is not a <CODE>set</CODE> method for the placeOfOrigin property.
+         * This is why there is not a <CODE>set</CODE> method for the placeOfOrigin property.</p>
          * 
          * <p>
          * For example, to add a new item, do as follows:
+         * </p>
          * <pre>
-         *    getPlaceOfOrigin().add(newItem);
+         * getPlaceOfOrigin().add(newItem);
          * </pre>
          * 
          * 
          * <p>
          * Objects of the following type(s) are allowed in the list
          * {@link PlaceOfOriginType }
+         * </p>
          * 
          * 
+         * @return
+         *     The value of the placeOfOrigin property.
          */
         public List<PlaceOfOriginType> getPlaceOfOrigin() {
             if (placeOfOrigin == null) {
-                placeOfOrigin = new ArrayList<PlaceOfOriginType>();
+                placeOfOrigin = new ArrayList<>();
             }
             return this.placeOfOrigin;
         }

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/BirthplaceType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/BirthplaceType.java
@@ -1,70 +1,70 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import ch.ech.xmlns.ech_0007._3.SwissMunicipalityType;
 import ch.ech.xmlns.ech_0008._2.CountryType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 
 /**
- * <p>Java class for birthplaceType complex type.
+ * <p>Java class for birthplaceType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="birthplaceType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;choice&gt;
- *         &lt;element name="unknown" type="{http://www.ech.ch/xmlns/eCH-0011/3}unknownType"/&gt;
- *         &lt;element name="swissTown"&gt;
- *           &lt;complexType&gt;
- *             &lt;complexContent&gt;
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *                 &lt;sequence&gt;
- *                   &lt;element name="country"&gt;
- *                     &lt;simpleType&gt;
- *                       &lt;restriction base="{http://www.ech.ch/xmlns/eCH-0010/3}countryType"&gt;
- *                         &lt;enumeration value="CH"/&gt;
- *                       &lt;/restriction&gt;
- *                     &lt;/simpleType&gt;
- *                   &lt;/element&gt;
- *                   &lt;element name="municipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/&gt;
- *                 &lt;/sequence&gt;
- *               &lt;/restriction&gt;
- *             &lt;/complexContent&gt;
- *           &lt;/complexType&gt;
- *         &lt;/element&gt;
- *         &lt;element name="foreignCountry"&gt;
- *           &lt;complexType&gt;
- *             &lt;complexContent&gt;
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *                 &lt;sequence&gt;
- *                   &lt;element name="country" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryType"/&gt;
- *                   &lt;element name="foreignBirthTown" minOccurs="0"&gt;
- *                     &lt;simpleType&gt;
- *                       &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *                         &lt;whiteSpace value="collapse"/&gt;
- *                         &lt;maxLength value="100"/&gt;
- *                       &lt;/restriction&gt;
- *                     &lt;/simpleType&gt;
- *                   &lt;/element&gt;
- *                 &lt;/sequence&gt;
- *               &lt;/restriction&gt;
- *             &lt;/complexContent&gt;
- *           &lt;/complexType&gt;
- *         &lt;/element&gt;
- *       &lt;/choice&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="birthplaceType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <choice>
+ *         <element name="unknown" type="{http://www.ech.ch/xmlns/eCH-0011/3}unknownType"/>
+ *         <element name="swissTown">
+ *           <complexType>
+ *             <complexContent>
+ *               <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *                 <sequence>
+ *                   <element name="country">
+ *                     <simpleType>
+ *                       <restriction base="{http://www.ech.ch/xmlns/eCH-0010/3}countryType">
+ *                         <enumeration value="CH"/>
+ *                       </restriction>
+ *                     </simpleType>
+ *                   </element>
+ *                   <element name="municipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/>
+ *                 </sequence>
+ *               </restriction>
+ *             </complexContent>
+ *           </complexType>
+ *         </element>
+ *         <element name="foreignCountry">
+ *           <complexType>
+ *             <complexContent>
+ *               <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *                 <sequence>
+ *                   <element name="country" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryType"/>
+ *                   <element name="foreignBirthTown" minOccurs="0">
+ *                     <simpleType>
+ *                       <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *                         <whiteSpace value="collapse"/>
+ *                         <maxLength value="100"/>
+ *                       </restriction>
+ *                     </simpleType>
+ *                   </element>
+ *                 </sequence>
+ *               </restriction>
+ *             </complexContent>
+ *           </complexType>
+ *         </element>
+ *       </choice>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */
@@ -181,29 +181,29 @@ public class BirthplaceType {
 
 
     /**
-     * <p>Java class for anonymous complex type.
+     * <p>Java class for anonymous complex type</p>.
      * 
-     * <p>The following schema fragment specifies the expected content contained within this class.
+     * <p>The following schema fragment specifies the expected content contained within this class.</p>
      * 
-     * <pre>
-     * &lt;complexType&gt;
-     *   &lt;complexContent&gt;
-     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
-     *       &lt;sequence&gt;
-     *         &lt;element name="country" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryType"/&gt;
-     *         &lt;element name="foreignBirthTown" minOccurs="0"&gt;
-     *           &lt;simpleType&gt;
-     *             &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
-     *               &lt;whiteSpace value="collapse"/&gt;
-     *               &lt;maxLength value="100"/&gt;
-     *             &lt;/restriction&gt;
-     *           &lt;/simpleType&gt;
-     *         &lt;/element&gt;
-     *       &lt;/sequence&gt;
-     *     &lt;/restriction&gt;
-     *   &lt;/complexContent&gt;
-     * &lt;/complexType&gt;
-     * </pre>
+     * <pre>{@code
+     * <complexType>
+     *   <complexContent>
+     *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+     *       <sequence>
+     *         <element name="country" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryType"/>
+     *         <element name="foreignBirthTown" minOccurs="0">
+     *           <simpleType>
+     *             <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+     *               <whiteSpace value="collapse"/>
+     *               <maxLength value="100"/>
+     *             </restriction>
+     *           </simpleType>
+     *         </element>
+     *       </sequence>
+     *     </restriction>
+     *   </complexContent>
+     * </complexType>
+     * }</pre>
      * 
      * 
      */
@@ -285,28 +285,28 @@ public class BirthplaceType {
 
 
     /**
-     * <p>Java class for anonymous complex type.
+     * <p>Java class for anonymous complex type</p>.
      * 
-     * <p>The following schema fragment specifies the expected content contained within this class.
+     * <p>The following schema fragment specifies the expected content contained within this class.</p>
      * 
-     * <pre>
-     * &lt;complexType&gt;
-     *   &lt;complexContent&gt;
-     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
-     *       &lt;sequence&gt;
-     *         &lt;element name="country"&gt;
-     *           &lt;simpleType&gt;
-     *             &lt;restriction base="{http://www.ech.ch/xmlns/eCH-0010/3}countryType"&gt;
-     *               &lt;enumeration value="CH"/&gt;
-     *             &lt;/restriction&gt;
-     *           &lt;/simpleType&gt;
-     *         &lt;/element&gt;
-     *         &lt;element name="municipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/&gt;
-     *       &lt;/sequence&gt;
-     *     &lt;/restriction&gt;
-     *   &lt;/complexContent&gt;
-     * &lt;/complexType&gt;
-     * </pre>
+     * <pre>{@code
+     * <complexType>
+     *   <complexContent>
+     *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+     *       <sequence>
+     *         <element name="country">
+     *           <simpleType>
+     *             <restriction base="{http://www.ech.ch/xmlns/eCH-0010/3}countryType">
+     *               <enumeration value="CH"/>
+     *             </restriction>
+     *           </simpleType>
+     *         </element>
+     *         <element name="municipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/>
+     *       </sequence>
+     *     </restriction>
+     *   </complexContent>
+     * </complexType>
+     * }</pre>
      * 
      * 
      */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/DestinationType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/DestinationType.java
@@ -1,56 +1,56 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
 import ch.ech.xmlns.ech_0007._3.SwissMunicipalityType;
 import ch.ech.xmlns.ech_0008._2.CountryType;
 import ch.ech.xmlns.ech_0010._3.AddressInformationType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for destinationType complex type.
+ * <p>Java class for destinationType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="destinationType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;choice&gt;
- *           &lt;element name="unknown" type="{http://www.ech.ch/xmlns/eCH-0011/3}unknownType"/&gt;
- *           &lt;element name="swissTown" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/&gt;
- *           &lt;element name="foreignCountry"&gt;
- *             &lt;complexType&gt;
- *               &lt;complexContent&gt;
- *                 &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *                   &lt;choice&gt;
- *                     &lt;sequence&gt;
- *                       &lt;element name="country" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryType"/&gt;
- *                       &lt;element name="town" minOccurs="0"&gt;
- *                         &lt;simpleType&gt;
- *                           &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *                             &lt;whiteSpace value="collapse"/&gt;
- *                             &lt;maxLength value="100"/&gt;
- *                           &lt;/restriction&gt;
- *                         &lt;/simpleType&gt;
- *                       &lt;/element&gt;
- *                     &lt;/sequence&gt;
- *                   &lt;/choice&gt;
- *                 &lt;/restriction&gt;
- *               &lt;/complexContent&gt;
- *             &lt;/complexType&gt;
- *           &lt;/element&gt;
- *         &lt;/choice&gt;
- *         &lt;element name="mailAddress" type="{http://www.ech.ch/xmlns/eCH-0010/3}addressInformationType" minOccurs="0"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="destinationType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <choice>
+ *           <element name="unknown" type="{http://www.ech.ch/xmlns/eCH-0011/3}unknownType"/>
+ *           <element name="swissTown" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/>
+ *           <element name="foreignCountry">
+ *             <complexType>
+ *               <complexContent>
+ *                 <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *                   <choice>
+ *                     <sequence>
+ *                       <element name="country" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryType"/>
+ *                       <element name="town" minOccurs="0">
+ *                         <simpleType>
+ *                           <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *                             <whiteSpace value="collapse"/>
+ *                             <maxLength value="100"/>
+ *                           </restriction>
+ *                         </simpleType>
+ *                       </element>
+ *                     </sequence>
+ *                   </choice>
+ *                 </restriction>
+ *               </complexContent>
+ *             </complexType>
+ *           </element>
+ *         </choice>
+ *         <element name="mailAddress" type="{http://www.ech.ch/xmlns/eCH-0010/3}addressInformationType" minOccurs="0"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */
@@ -204,31 +204,31 @@ public class DestinationType {
 
 
     /**
-     * <p>Java class for anonymous complex type.
+     * <p>Java class for anonymous complex type</p>.
      * 
-     * <p>The following schema fragment specifies the expected content contained within this class.
+     * <p>The following schema fragment specifies the expected content contained within this class.</p>
      * 
-     * <pre>
-     * &lt;complexType&gt;
-     *   &lt;complexContent&gt;
-     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
-     *       &lt;choice&gt;
-     *         &lt;sequence&gt;
-     *           &lt;element name="country" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryType"/&gt;
-     *           &lt;element name="town" minOccurs="0"&gt;
-     *             &lt;simpleType&gt;
-     *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
-     *                 &lt;whiteSpace value="collapse"/&gt;
-     *                 &lt;maxLength value="100"/&gt;
-     *               &lt;/restriction&gt;
-     *             &lt;/simpleType&gt;
-     *           &lt;/element&gt;
-     *         &lt;/sequence&gt;
-     *       &lt;/choice&gt;
-     *     &lt;/restriction&gt;
-     *   &lt;/complexContent&gt;
-     * &lt;/complexType&gt;
-     * </pre>
+     * <pre>{@code
+     * <complexType>
+     *   <complexContent>
+     *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+     *       <choice>
+     *         <sequence>
+     *           <element name="country" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryType"/>
+     *           <element name="town" minOccurs="0">
+     *             <simpleType>
+     *               <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+     *                 <whiteSpace value="collapse"/>
+     *                 <maxLength value="100"/>
+     *               </restriction>
+     *             </simpleType>
+     *           </element>
+     *         </sequence>
+     *       </choice>
+     *     </restriction>
+     *   </complexContent>
+     * </complexType>
+     * }</pre>
      * 
      * 
      */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/DwellingAddressType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/DwellingAddressType.java
@@ -1,55 +1,55 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import javax.xml.datatype.XMLGregorianCalendar;
 import ch.ech.xmlns.ech_0010._3.SwissAddressInformationType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 
 /**
- * <p>Java class for dwellingAddressType complex type.
+ * <p>Java class for dwellingAddressType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="dwellingAddressType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;choice minOccurs="0"&gt;
- *           &lt;sequence&gt;
- *             &lt;element name="EGID" type="{http://www.ech.ch/xmlns/eCH-0011/3}EGIDType"/&gt;
- *             &lt;choice minOccurs="0"&gt;
- *               &lt;element name="EWID" type="{http://www.ech.ch/xmlns/eCH-0011/3}EWIDType"/&gt;
- *               &lt;element name="householdID" type="{http://www.w3.org/2001/XMLSchema}token" minOccurs="0"/&gt;
- *             &lt;/choice&gt;
- *           &lt;/sequence&gt;
- *           &lt;element name="withoutEGID"&gt;
- *             &lt;complexType&gt;
- *               &lt;complexContent&gt;
- *                 &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *                   &lt;sequence&gt;
- *                     &lt;element name="householdID" type="{http://www.w3.org/2001/XMLSchema}token"/&gt;
- *                   &lt;/sequence&gt;
- *                 &lt;/restriction&gt;
- *               &lt;/complexContent&gt;
- *             &lt;/complexType&gt;
- *           &lt;/element&gt;
- *         &lt;/choice&gt;
- *         &lt;element name="address" type="{http://www.ech.ch/xmlns/eCH-0010/3}swissAddressInformationType"/&gt;
- *         &lt;element name="typeOfHousehold" type="{http://www.ech.ch/xmlns/eCH-0011/3}typeOfHouseholdType"/&gt;
- *         &lt;element name="movingDate" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="dwellingAddressType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <choice minOccurs="0">
+ *           <sequence>
+ *             <element name="EGID" type="{http://www.ech.ch/xmlns/eCH-0011/3}EGIDType"/>
+ *             <choice minOccurs="0">
+ *               <element name="EWID" type="{http://www.ech.ch/xmlns/eCH-0011/3}EWIDType"/>
+ *               <element name="householdID" type="{http://www.w3.org/2001/XMLSchema}token" minOccurs="0"/>
+ *             </choice>
+ *           </sequence>
+ *           <element name="withoutEGID">
+ *             <complexType>
+ *               <complexContent>
+ *                 <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *                   <sequence>
+ *                     <element name="householdID" type="{http://www.w3.org/2001/XMLSchema}token"/>
+ *                   </sequence>
+ *                 </restriction>
+ *               </complexContent>
+ *             </complexType>
+ *           </element>
+ *         </choice>
+ *         <element name="address" type="{http://www.ech.ch/xmlns/eCH-0010/3}swissAddressInformationType"/>
+ *         <element name="typeOfHousehold" type="{http://www.ech.ch/xmlns/eCH-0011/3}typeOfHouseholdType"/>
+ *         <element name="movingDate" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */
@@ -295,21 +295,21 @@ public class DwellingAddressType {
 
 
     /**
-     * <p>Java class for anonymous complex type.
+     * <p>Java class for anonymous complex type</p>.
      * 
-     * <p>The following schema fragment specifies the expected content contained within this class.
+     * <p>The following schema fragment specifies the expected content contained within this class.</p>
      * 
-     * <pre>
-     * &lt;complexType&gt;
-     *   &lt;complexContent&gt;
-     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
-     *       &lt;sequence&gt;
-     *         &lt;element name="householdID" type="{http://www.w3.org/2001/XMLSchema}token"/&gt;
-     *       &lt;/sequence&gt;
-     *     &lt;/restriction&gt;
-     *   &lt;/complexContent&gt;
-     * &lt;/complexType&gt;
-     * </pre>
+     * <pre>{@code
+     * <complexType>
+     *   <complexContent>
+     *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+     *       <sequence>
+     *         <element name="householdID" type="{http://www.w3.org/2001/XMLSchema}token"/>
+     *       </sequence>
+     *     </restriction>
+     *   </complexContent>
+     * </complexType>
+     * }</pre>
      * 
      * 
      */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/MainResidenceType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/MainResidenceType.java
@@ -3,47 +3,47 @@ package ch.ech.xmlns.ech_0011._3;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
 import javax.xml.datatype.XMLGregorianCalendar;
 import ch.ech.xmlns.ech_0007._3.SwissMunicipalityType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for mainResidenceType complex type.
+ * <p>Java class for mainResidenceType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="mainResidenceType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="mainResidence"&gt;
- *           &lt;complexType&gt;
- *             &lt;complexContent&gt;
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *                 &lt;sequence&gt;
- *                   &lt;element name="reportingMunicipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/&gt;
- *                   &lt;element name="arrivalDate" type="{http://www.w3.org/2001/XMLSchema}date"/&gt;
- *                   &lt;element name="comesFrom" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType" minOccurs="0"/&gt;
- *                   &lt;element name="dwellingAddress" type="{http://www.ech.ch/xmlns/eCH-0011/3}dwellingAddressType"/&gt;
- *                   &lt;element name="departureDate" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/&gt;
- *                   &lt;element name="goesTo" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType" minOccurs="0"/&gt;
- *                 &lt;/sequence&gt;
- *               &lt;/restriction&gt;
- *             &lt;/complexContent&gt;
- *           &lt;/complexType&gt;
- *         &lt;/element&gt;
- *         &lt;element name="secondaryResidence" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType" maxOccurs="unbounded" minOccurs="0"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="mainResidenceType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="mainResidence">
+ *           <complexType>
+ *             <complexContent>
+ *               <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *                 <sequence>
+ *                   <element name="reportingMunicipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/>
+ *                   <element name="arrivalDate" type="{http://www.w3.org/2001/XMLSchema}date"/>
+ *                   <element name="comesFrom" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType" minOccurs="0"/>
+ *                   <element name="dwellingAddress" type="{http://www.ech.ch/xmlns/eCH-0011/3}dwellingAddressType"/>
+ *                   <element name="departureDate" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/>
+ *                   <element name="goesTo" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType" minOccurs="0"/>
+ *                 </sequence>
+ *               </restriction>
+ *             </complexContent>
+ *           </complexType>
+ *         </element>
+ *         <element name="secondaryResidence" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType" maxOccurs="unbounded" minOccurs="0"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */
@@ -89,28 +89,31 @@ public class MainResidenceType {
     /**
      * Gets the value of the secondaryResidence property.
      * 
-     * <p>
-     * This accessor method returns a reference to the live list,
+     * <p>This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
-     * This is why there is not a <CODE>set</CODE> method for the secondaryResidence property.
+     * This is why there is not a <CODE>set</CODE> method for the secondaryResidence property.</p>
      * 
      * <p>
      * For example, to add a new item, do as follows:
+     * </p>
      * <pre>
-     *    getSecondaryResidence().add(newItem);
+     * getSecondaryResidence().add(newItem);
      * </pre>
      * 
      * 
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link SwissMunicipalityType }
+     * </p>
      * 
      * 
+     * @return
+     *     The value of the secondaryResidence property.
      */
     public List<SwissMunicipalityType> getSecondaryResidence() {
         if (secondaryResidence == null) {
-            secondaryResidence = new ArrayList<SwissMunicipalityType>();
+            secondaryResidence = new ArrayList<>();
         }
         return this.secondaryResidence;
     }
@@ -138,26 +141,26 @@ public class MainResidenceType {
 
 
     /**
-     * <p>Java class for anonymous complex type.
+     * <p>Java class for anonymous complex type</p>.
      * 
-     * <p>The following schema fragment specifies the expected content contained within this class.
+     * <p>The following schema fragment specifies the expected content contained within this class.</p>
      * 
-     * <pre>
-     * &lt;complexType&gt;
-     *   &lt;complexContent&gt;
-     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
-     *       &lt;sequence&gt;
-     *         &lt;element name="reportingMunicipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/&gt;
-     *         &lt;element name="arrivalDate" type="{http://www.w3.org/2001/XMLSchema}date"/&gt;
-     *         &lt;element name="comesFrom" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType" minOccurs="0"/&gt;
-     *         &lt;element name="dwellingAddress" type="{http://www.ech.ch/xmlns/eCH-0011/3}dwellingAddressType"/&gt;
-     *         &lt;element name="departureDate" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/&gt;
-     *         &lt;element name="goesTo" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType" minOccurs="0"/&gt;
-     *       &lt;/sequence&gt;
-     *     &lt;/restriction&gt;
-     *   &lt;/complexContent&gt;
-     * &lt;/complexType&gt;
-     * </pre>
+     * <pre>{@code
+     * <complexType>
+     *   <complexContent>
+     *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+     *       <sequence>
+     *         <element name="reportingMunicipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/>
+     *         <element name="arrivalDate" type="{http://www.w3.org/2001/XMLSchema}date"/>
+     *         <element name="comesFrom" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType" minOccurs="0"/>
+     *         <element name="dwellingAddress" type="{http://www.ech.ch/xmlns/eCH-0011/3}dwellingAddressType"/>
+     *         <element name="departureDate" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/>
+     *         <element name="goesTo" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType" minOccurs="0"/>
+     *       </sequence>
+     *     </restriction>
+     *   </complexContent>
+     * </complexType>
+     * }</pre>
      * 
      * 
      */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/MaritalDataType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/MaritalDataType.java
@@ -1,46 +1,46 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
 import javax.xml.datatype.XMLGregorianCalendar;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for maritalDataType complex type.
+ * <p>Java class for maritalDataType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="maritalDataType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="maritalStatus" type="{http://www.ech.ch/xmlns/eCH-0011/3}maritalStatusType"/&gt;
- *         &lt;element name="dateOfMaritalStatus" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/&gt;
- *         &lt;element name="separation" type="{http://www.ech.ch/xmlns/eCH-0011/3}separationType" minOccurs="0"/&gt;
- *         &lt;element name="dateOfSeparation" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/&gt;
- *         &lt;element name="cancelationReason" minOccurs="0"&gt;
- *           &lt;simpleType&gt;
- *             &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *               &lt;enumeration value="1"/&gt;
- *               &lt;enumeration value="2"/&gt;
- *               &lt;enumeration value="3"/&gt;
- *               &lt;enumeration value="4"/&gt;
- *               &lt;enumeration value="9"/&gt;
- *             &lt;/restriction&gt;
- *           &lt;/simpleType&gt;
- *         &lt;/element&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="maritalDataType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="maritalStatus" type="{http://www.ech.ch/xmlns/eCH-0011/3}maritalStatusType"/>
+ *         <element name="dateOfMaritalStatus" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/>
+ *         <element name="separation" type="{http://www.ech.ch/xmlns/eCH-0011/3}separationType" minOccurs="0"/>
+ *         <element name="dateOfSeparation" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/>
+ *         <element name="cancelationReason" minOccurs="0">
+ *           <simpleType>
+ *             <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *               <enumeration value="1"/>
+ *               <enumeration value="2"/>
+ *               <enumeration value="3"/>
+ *               <enumeration value="4"/>
+ *               <enumeration value="9"/>
+ *             </restriction>
+ *           </simpleType>
+ *         </element>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */
@@ -207,21 +207,20 @@ public class MaritalDataType {
 
 
     /**
-     * <p>Java class for null.
+     * <p>Java class for null</p>.
      * 
-     * <p>The following schema fragment specifies the expected content contained within this class.
-     * <p>
-     * <pre>
-     * &lt;simpleType&gt;
-     *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
-     *     &lt;enumeration value="1"/&gt;
-     *     &lt;enumeration value="2"/&gt;
-     *     &lt;enumeration value="3"/&gt;
-     *     &lt;enumeration value="4"/&gt;
-     *     &lt;enumeration value="9"/&gt;
-     *   &lt;/restriction&gt;
-     * &lt;/simpleType&gt;
-     * </pre>
+     * <p>The following schema fragment specifies the expected content contained within this class.</p>
+     * <pre>{@code
+     * <simpleType>
+     *   <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+     *     <enumeration value="1"/>
+     *     <enumeration value="2"/>
+     *     <enumeration value="3"/>
+     *     <enumeration value="4"/>
+     *     <enumeration value="9"/>
+     *   </restriction>
+     * </simpleType>
+     * }</pre>
      * 
      */
     @XmlType(name = "")
@@ -244,10 +243,26 @@ public class MaritalDataType {
             value = v;
         }
 
+        /**
+         * Gets the value associated to the enum constant.
+         * 
+         * @return
+         *     The value linked to the enum.
+         */
         public String value() {
             return value;
         }
 
+        /**
+         * Gets the enum associated to the value passed as parameter.
+         * 
+         * @param v
+         *     The value to get the enum from.
+         * @return
+         *     The enum which corresponds to the value, if it exists.
+         * @throws IllegalArgumentException
+         *     If no value matches in the enum declaration.
+         */
         public static MaritalDataType.CancellationReason fromValue(String v) {
             for (MaritalDataType.CancellationReason c: MaritalDataType.CancellationReason.values()) {
                 if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/MaritalStatusType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/MaritalStatusType.java
@@ -1,29 +1,30 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for maritalStatusType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="maritalStatusType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *     &lt;enumeration value="1"/&gt;
- *     &lt;enumeration value="2"/&gt;
- *     &lt;enumeration value="3"/&gt;
- *     &lt;enumeration value="4"/&gt;
- *     &lt;enumeration value="5"/&gt;
- *     &lt;enumeration value="6"/&gt;
- *     &lt;enumeration value="7"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for maritalStatusType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="maritalStatusType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     <enumeration value="1"/>
+ *     <enumeration value="2"/>
+ *     <enumeration value="3"/>
+ *     <enumeration value="4"/>
+ *     <enumeration value="5"/>
+ *     <enumeration value="6"/>
+ *     <enumeration value="7"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "maritalStatusType")
@@ -50,10 +51,26 @@ public enum MaritalStatusType {
         value = v;
     }
 
+    /**
+     * Gets the value associated to the enum constant.
+     * 
+     * @return
+     *     The value linked to the enum.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Gets the enum associated to the value passed as parameter.
+     * 
+     * @param v
+     *     The value to get the enum from.
+     * @return
+     *     The enum which corresponds to the value, if it exists.
+     * @throws IllegalArgumentException
+     *     If no value matches in the enum declaration.
+     */
     public static MaritalStatusType fromValue(String v) {
         for (MaritalStatusType c: MaritalStatusType.values()) {
             if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/NationalityStatusType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/NationalityStatusType.java
@@ -1,25 +1,26 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for nationalityStatusType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="nationalityStatusType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *     &lt;enumeration value="0"/&gt;
- *     &lt;enumeration value="1"/&gt;
- *     &lt;enumeration value="2"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for nationalityStatusType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="nationalityStatusType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     <enumeration value="0"/>
+ *     <enumeration value="1"/>
+ *     <enumeration value="2"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "nationalityStatusType")
@@ -38,10 +39,26 @@ public enum NationalityStatusType {
         value = v;
     }
 
+    /**
+     * Gets the value associated to the enum constant.
+     * 
+     * @return
+     *     The value linked to the enum.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Gets the enum associated to the value passed as parameter.
+     * 
+     * @param v
+     *     The value to get the enum from.
+     * @return
+     *     The enum which corresponds to the value, if it exists.
+     * @throws IllegalArgumentException
+     *     If no value matches in the enum declaration.
+     */
     public static NationalityStatusType fromValue(String v) {
         for (NationalityStatusType c: NationalityStatusType.values()) {
             if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/NationalityType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/NationalityType.java
@@ -1,31 +1,31 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
 import ch.ech.xmlns.ech_0008._2.CountryType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for nationalityType complex type.
+ * <p>Java class for nationalityType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="nationalityType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="nationalityStatus" type="{http://www.ech.ch/xmlns/eCH-0011/3}nationalityStatusType"/&gt;
- *         &lt;element name="country" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryType" minOccurs="0"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="nationalityType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="nationalityStatus" type="{http://www.ech.ch/xmlns/eCH-0011/3}nationalityStatusType"/>
+ *         <element name="country" type="{http://www.ech.ch/xmlns/eCH-0008/2}countryType" minOccurs="0"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/ObjectFactory.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/ObjectFactory.java
@@ -1,14 +1,14 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlRegistry;
+import jakarta.xml.bind.annotation.XmlRegistry;
 
 
 /**
  * This object contains factory methods for each 
  * Java content interface and Java element interface 
  * generated in the ch.ech.xmlns.ech_0011._3 package. 
- * <p>An ObjectFactory allows you to programatically 
+ * <p>An ObjectFactory allows you to programmatically 
  * construct new instances of the Java representation 
  * for XML content. The Java representation of XML 
  * content can consist of schema derived interfaces 
@@ -32,6 +32,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link MaritalDataType }
      * 
+     * @return
+     *     the new instance of {@link MaritalDataType }
      */
     public MaritalDataType createMaritalDataType() {
         return new MaritalDataType();
@@ -40,6 +42,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link BirthplaceType }
      * 
+     * @return
+     *     the new instance of {@link BirthplaceType }
      */
     public BirthplaceType createBirthplaceType() {
         return new BirthplaceType();
@@ -48,6 +52,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link DwellingAddressType }
      * 
+     * @return
+     *     the new instance of {@link DwellingAddressType }
      */
     public DwellingAddressType createDwellingAddressType() {
         return new DwellingAddressType();
@@ -56,6 +62,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link DestinationType }
      * 
+     * @return
+     *     the new instance of {@link DestinationType }
      */
     public DestinationType createDestinationType() {
         return new DestinationType();
@@ -64,6 +72,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link OtherResidenceType }
      * 
+     * @return
+     *     the new instance of {@link OtherResidenceType }
      */
     public OtherResidenceType createOtherResidenceType() {
         return new OtherResidenceType();
@@ -72,6 +82,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link SecondaryResidenceType }
      * 
+     * @return
+     *     the new instance of {@link SecondaryResidenceType }
      */
     public SecondaryResidenceType createSecondaryResidenceType() {
         return new SecondaryResidenceType();
@@ -80,6 +92,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link MainResidenceType }
      * 
+     * @return
+     *     the new instance of {@link MainResidenceType }
      */
     public MainResidenceType createMainResidenceType() {
         return new MainResidenceType();
@@ -88,6 +102,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link AnyPersonType }
      * 
+     * @return
+     *     the new instance of {@link AnyPersonType }
      */
     public AnyPersonType createAnyPersonType() {
         return new AnyPersonType();
@@ -96,6 +112,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link PersonType }
      * 
+     * @return
+     *     the new instance of {@link PersonType }
      */
     public PersonType createPersonType() {
         return new PersonType();
@@ -104,6 +122,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link PersonType.Coredata }
      * 
+     * @return
+     *     the new instance of {@link PersonType.Coredata }
      */
     public PersonType.Coredata createPersonTypeCoredata() {
         return new PersonType.Coredata();
@@ -112,6 +132,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link ReportedPersonType }
      * 
+     * @return
+     *     the new instance of {@link ReportedPersonType }
      */
     public ReportedPersonType createReportedPersonType() {
         return new ReportedPersonType();
@@ -120,6 +142,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link PersonRoot }
      * 
+     * @return
+     *     the new instance of {@link PersonRoot }
      */
     public PersonRoot createPersonRoot() {
         return new PersonRoot();
@@ -128,6 +152,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link NationalityType }
      * 
+     * @return
+     *     the new instance of {@link NationalityType }
      */
     public NationalityType createNationalityType() {
         return new NationalityType();
@@ -136,6 +162,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link PlaceOfOriginType }
      * 
+     * @return
+     *     the new instance of {@link PlaceOfOriginType }
      */
     public PlaceOfOriginType createPlaceOfOriginType() {
         return new PlaceOfOriginType();
@@ -144,6 +172,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link SwissMunicipalityWithoutBFS }
      * 
+     * @return
+     *     the new instance of {@link SwissMunicipalityWithoutBFS }
      */
     public SwissMunicipalityWithoutBFS createSwissMunicipalityWithoutBFS() {
         return new SwissMunicipalityWithoutBFS();
@@ -152,6 +182,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link PartnerIdOrganisationType }
      * 
+     * @return
+     *     the new instance of {@link PartnerIdOrganisationType }
      */
     public PartnerIdOrganisationType createPartnerIdOrganisationType() {
         return new PartnerIdOrganisationType();
@@ -160,6 +192,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link BirthplaceType.SwissTown }
      * 
+     * @return
+     *     the new instance of {@link BirthplaceType.SwissTown }
      */
     public BirthplaceType.SwissTown createBirthplaceTypeSwissTown() {
         return new BirthplaceType.SwissTown();
@@ -168,6 +202,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link BirthplaceType.ForeignCountry }
      * 
+     * @return
+     *     the new instance of {@link BirthplaceType.ForeignCountry }
      */
     public BirthplaceType.ForeignCountry createBirthplaceTypeForeignCountry() {
         return new BirthplaceType.ForeignCountry();
@@ -176,6 +212,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link DwellingAddressType.WithoutEGID }
      * 
+     * @return
+     *     the new instance of {@link DwellingAddressType.WithoutEGID }
      */
     public DwellingAddressType.WithoutEGID createDwellingAddressTypeWithoutEGID() {
         return new DwellingAddressType.WithoutEGID();
@@ -184,6 +222,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link DestinationType.ForeignCountry }
      * 
+     * @return
+     *     the new instance of {@link DestinationType.ForeignCountry }
      */
     public DestinationType.ForeignCountry createDestinationTypeForeignCountry() {
         return new DestinationType.ForeignCountry();
@@ -192,6 +232,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link OtherResidenceType.SecondaryResidenceInformation }
      * 
+     * @return
+     *     the new instance of {@link OtherResidenceType.SecondaryResidenceInformation }
      */
     public OtherResidenceType.SecondaryResidenceInformation createOtherResidenceTypeSecondaryResidenceInformation() {
         return new OtherResidenceType.SecondaryResidenceInformation();
@@ -200,6 +242,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link SecondaryResidenceType.SecondaryResidence }
      * 
+     * @return
+     *     the new instance of {@link SecondaryResidenceType.SecondaryResidence }
      */
     public SecondaryResidenceType.SecondaryResidence createSecondaryResidenceTypeSecondaryResidence() {
         return new SecondaryResidenceType.SecondaryResidence();
@@ -208,6 +252,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link MainResidenceType.MainResidence }
      * 
+     * @return
+     *     the new instance of {@link MainResidenceType.MainResidence }
      */
     public MainResidenceType.MainResidence createMainResidenceTypeMainResidence() {
         return new MainResidenceType.MainResidence();
@@ -216,6 +262,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link AnyPersonType.Swiss }
      * 
+     * @return
+     *     the new instance of {@link AnyPersonType.Swiss }
      */
     public AnyPersonType.Swiss createAnyPersonTypeSwiss() {
         return new AnyPersonType.Swiss();
@@ -224,6 +272,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link AnyPersonType.Foreigner }
      * 
+     * @return
+     *     the new instance of {@link AnyPersonType.Foreigner }
      */
     public AnyPersonType.Foreigner createAnyPersonTypeForeigner() {
         return new AnyPersonType.Foreigner();
@@ -232,6 +282,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link PersonType.Coredata.Contact }
      * 
+     * @return
+     *     the new instance of {@link PersonType.Coredata.Contact }
      */
     public PersonType.Coredata.Contact createPersonTypeCoredataContact() {
         return new PersonType.Coredata.Contact();

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/OtherResidenceType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/OtherResidenceType.java
@@ -1,46 +1,46 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
 import javax.xml.datatype.XMLGregorianCalendar;
 import ch.ech.xmlns.ech_0007._3.SwissMunicipalityType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for otherResidenceType complex type.
+ * <p>Java class for otherResidenceType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="otherResidenceType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="secondaryResidenceInformation"&gt;
- *           &lt;complexType&gt;
- *             &lt;complexContent&gt;
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *                 &lt;sequence&gt;
- *                   &lt;element name="reportingMunicipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/&gt;
- *                   &lt;element name="arrivalDate" type="{http://www.w3.org/2001/XMLSchema}date"/&gt;
- *                   &lt;element name="comesFrom" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType"/&gt;
- *                   &lt;element name="dwellingAddress" type="{http://www.ech.ch/xmlns/eCH-0011/3}dwellingAddressType"/&gt;
- *                   &lt;element name="departureDate" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/&gt;
- *                   &lt;element name="goesTo" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType" minOccurs="0"/&gt;
- *                 &lt;/sequence&gt;
- *               &lt;/restriction&gt;
- *             &lt;/complexContent&gt;
- *           &lt;/complexType&gt;
- *         &lt;/element&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="otherResidenceType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="secondaryResidenceInformation">
+ *           <complexType>
+ *             <complexContent>
+ *               <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *                 <sequence>
+ *                   <element name="reportingMunicipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/>
+ *                   <element name="arrivalDate" type="{http://www.w3.org/2001/XMLSchema}date"/>
+ *                   <element name="comesFrom" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType"/>
+ *                   <element name="dwellingAddress" type="{http://www.ech.ch/xmlns/eCH-0011/3}dwellingAddressType"/>
+ *                   <element name="departureDate" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/>
+ *                   <element name="goesTo" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType" minOccurs="0"/>
+ *                 </sequence>
+ *               </restriction>
+ *             </complexContent>
+ *           </complexType>
+ *         </element>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */
@@ -90,26 +90,26 @@ public class OtherResidenceType {
 
 
     /**
-     * <p>Java class for anonymous complex type.
+     * <p>Java class for anonymous complex type</p>.
      * 
-     * <p>The following schema fragment specifies the expected content contained within this class.
+     * <p>The following schema fragment specifies the expected content contained within this class.</p>
      * 
-     * <pre>
-     * &lt;complexType&gt;
-     *   &lt;complexContent&gt;
-     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
-     *       &lt;sequence&gt;
-     *         &lt;element name="reportingMunicipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/&gt;
-     *         &lt;element name="arrivalDate" type="{http://www.w3.org/2001/XMLSchema}date"/&gt;
-     *         &lt;element name="comesFrom" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType"/&gt;
-     *         &lt;element name="dwellingAddress" type="{http://www.ech.ch/xmlns/eCH-0011/3}dwellingAddressType"/&gt;
-     *         &lt;element name="departureDate" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/&gt;
-     *         &lt;element name="goesTo" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType" minOccurs="0"/&gt;
-     *       &lt;/sequence&gt;
-     *     &lt;/restriction&gt;
-     *   &lt;/complexContent&gt;
-     * &lt;/complexType&gt;
-     * </pre>
+     * <pre>{@code
+     * <complexType>
+     *   <complexContent>
+     *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+     *       <sequence>
+     *         <element name="reportingMunicipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/>
+     *         <element name="arrivalDate" type="{http://www.w3.org/2001/XMLSchema}date"/>
+     *         <element name="comesFrom" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType"/>
+     *         <element name="dwellingAddress" type="{http://www.ech.ch/xmlns/eCH-0011/3}dwellingAddressType"/>
+     *         <element name="departureDate" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/>
+     *         <element name="goesTo" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType" minOccurs="0"/>
+     *       </sequence>
+     *     </restriction>
+     *   </complexContent>
+     * </complexType>
+     * }</pre>
      * 
      * 
      */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/PartnerIdOrganisationType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/PartnerIdOrganisationType.java
@@ -3,30 +3,30 @@ package ch.ech.xmlns.ech_0011._3;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
 import ch.ech.xmlns.ech_0044._1.NamedPersonIdType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for partnerIdOrganisationType complex type.
+ * <p>Java class for partnerIdOrganisationType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="partnerIdOrganisationType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="localPersonId" type="{http://www.ech.ch/xmlns/eCH-0044/1}namedPersonIdType"/&gt;
- *         &lt;element name="OtherPersonId" type="{http://www.ech.ch/xmlns/eCH-0044/1}namedPersonIdType" maxOccurs="unbounded" minOccurs="0"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="partnerIdOrganisationType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="localPersonId" type="{http://www.ech.ch/xmlns/eCH-0044/1}namedPersonIdType"/>
+ *         <element name="OtherPersonId" type="{http://www.ech.ch/xmlns/eCH-0044/1}namedPersonIdType" maxOccurs="unbounded" minOccurs="0"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */
@@ -73,28 +73,31 @@ public class PartnerIdOrganisationType {
     /**
      * Gets the value of the otherPersonId property.
      * 
-     * <p>
-     * This accessor method returns a reference to the live list,
+     * <p>This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
-     * This is why there is not a <CODE>set</CODE> method for the otherPersonId property.
+     * This is why there is not a <CODE>set</CODE> method for the otherPersonId property.</p>
      * 
      * <p>
      * For example, to add a new item, do as follows:
+     * </p>
      * <pre>
-     *    getOtherPersonId().add(newItem);
+     * getOtherPersonId().add(newItem);
      * </pre>
      * 
      * 
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link NamedPersonIdType }
+     * </p>
      * 
      * 
+     * @return
+     *     The value of the otherPersonId property.
      */
     public List<NamedPersonIdType> getOtherPersonId() {
         if (otherPersonId == null) {
-            otherPersonId = new ArrayList<NamedPersonIdType>();
+            otherPersonId = new ArrayList<>();
         }
         return this.otherPersonId;
     }

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/PartnerShipAbolitionType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/PartnerShipAbolitionType.java
@@ -1,27 +1,28 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for partnerShipAbolitionType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="partnerShipAbolitionType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *     &lt;enumeration value="1"/&gt;
- *     &lt;enumeration value="2"/&gt;
- *     &lt;enumeration value="3"/&gt;
- *     &lt;enumeration value="4"/&gt;
- *     &lt;enumeration value="9"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for partnerShipAbolitionType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="partnerShipAbolitionType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     <enumeration value="1"/>
+ *     <enumeration value="2"/>
+ *     <enumeration value="3"/>
+ *     <enumeration value="4"/>
+ *     <enumeration value="9"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "partnerShipAbolitionType")
@@ -44,10 +45,26 @@ public enum PartnerShipAbolitionType {
         value = v;
     }
 
+    /**
+     * Gets the value associated to the enum constant.
+     * 
+     * @return
+     *     The value linked to the enum.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Gets the enum associated to the value passed as parameter.
+     * 
+     * @param v
+     *     The value to get the enum from.
+     * @return
+     *     The enum which corresponds to the value, if it exists.
+     * @throws IllegalArgumentException
+     *     If no value matches in the enum declaration.
+     */
     public static PartnerShipAbolitionType fromValue(String v) {
         for (PartnerShipAbolitionType c: PartnerShipAbolitionType.values()) {
             if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/PersonRoot.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/PersonRoot.java
@@ -1,29 +1,29 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for anonymous complex type.
+ * <p>Java class for anonymous complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="reportetPerson" type="{http://www.ech.ch/xmlns/eCH-0011/3}reportedPersonType"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType>
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="reportetPerson" type="{http://www.ech.ch/xmlns/eCH-0011/3}reportedPersonType"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/PersonType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/PersonType.java
@@ -1,72 +1,72 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import javax.xml.datatype.XMLGregorianCalendar;
 import ch.ech.xmlns.ech_0010._3.MailAddressType;
 import ch.ech.xmlns.ech_0044._1.PersonIdentificationPartnerType;
 import ch.ech.xmlns.ech_0044._1.PersonIdentificationType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 
 /**
- * <p>Java class for personType complex type.
+ * <p>Java class for personType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="personType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="personIdentification" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationType"/&gt;
- *         &lt;element name="coredata"&gt;
- *           &lt;complexType&gt;
- *             &lt;complexContent&gt;
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *                 &lt;sequence&gt;
- *                   &lt;element name="originalName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/&gt;
- *                   &lt;element name="alliancePartnershipName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/&gt;
- *                   &lt;element name="aliasName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/&gt;
- *                   &lt;element name="otherName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/&gt;
- *                   &lt;element name="callName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/&gt;
- *                   &lt;element name="placeOfBirth" type="{http://www.ech.ch/xmlns/eCH-0011/3}birthplaceType"/&gt;
- *                   &lt;element name="dateOfDeath" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/&gt;
- *                   &lt;element name="maritalData" type="{http://www.ech.ch/xmlns/eCH-0011/3}maritalDataType"/&gt;
- *                   &lt;element name="nationality" type="{http://www.ech.ch/xmlns/eCH-0011/3}nationalityType"/&gt;
- *                   &lt;element name="contact" minOccurs="0"&gt;
- *                     &lt;complexType&gt;
- *                       &lt;complexContent&gt;
- *                         &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *                           &lt;sequence&gt;
- *                             &lt;choice minOccurs="0"&gt;
- *                               &lt;element name="personIdentification" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationType"/&gt;
- *                               &lt;element name="personIdentificationPartner" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationPartnerType"/&gt;
- *                               &lt;element name="partnerIdOrgnisation" type="{http://www.ech.ch/xmlns/eCH-0011/3}partnerIdOrganisationType"/&gt;
- *                             &lt;/choice&gt;
- *                             &lt;element name="contactAddress" type="{http://www.ech.ch/xmlns/eCH-0010/3}mailAddressType"/&gt;
- *                           &lt;/sequence&gt;
- *                         &lt;/restriction&gt;
- *                       &lt;/complexContent&gt;
- *                     &lt;/complexType&gt;
- *                   &lt;/element&gt;
- *                   &lt;element name="languageOfCorrespondance" type="{http://www.ech.ch/xmlns/eCH-0011/3}languageType" minOccurs="0"/&gt;
- *                   &lt;element name="religion" type="{http://www.ech.ch/xmlns/eCH-0011/3}religionType"/&gt;
- *                 &lt;/sequence&gt;
- *               &lt;/restriction&gt;
- *             &lt;/complexContent&gt;
- *           &lt;/complexType&gt;
- *         &lt;/element&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="personType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="personIdentification" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationType"/>
+ *         <element name="coredata">
+ *           <complexType>
+ *             <complexContent>
+ *               <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *                 <sequence>
+ *                   <element name="originalName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/>
+ *                   <element name="alliancePartnershipName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/>
+ *                   <element name="aliasName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/>
+ *                   <element name="otherName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/>
+ *                   <element name="callName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/>
+ *                   <element name="placeOfBirth" type="{http://www.ech.ch/xmlns/eCH-0011/3}birthplaceType"/>
+ *                   <element name="dateOfDeath" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/>
+ *                   <element name="maritalData" type="{http://www.ech.ch/xmlns/eCH-0011/3}maritalDataType"/>
+ *                   <element name="nationality" type="{http://www.ech.ch/xmlns/eCH-0011/3}nationalityType"/>
+ *                   <element name="contact" minOccurs="0">
+ *                     <complexType>
+ *                       <complexContent>
+ *                         <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *                           <sequence>
+ *                             <choice minOccurs="0">
+ *                               <element name="personIdentification" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationType"/>
+ *                               <element name="personIdentificationPartner" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationPartnerType"/>
+ *                               <element name="partnerIdOrgnisation" type="{http://www.ech.ch/xmlns/eCH-0011/3}partnerIdOrganisationType"/>
+ *                             </choice>
+ *                             <element name="contactAddress" type="{http://www.ech.ch/xmlns/eCH-0010/3}mailAddressType"/>
+ *                           </sequence>
+ *                         </restriction>
+ *                       </complexContent>
+ *                     </complexType>
+ *                   </element>
+ *                   <element name="languageOfCorrespondance" type="{http://www.ech.ch/xmlns/eCH-0011/3}languageType" minOccurs="0"/>
+ *                   <element name="religion" type="{http://www.ech.ch/xmlns/eCH-0011/3}religionType"/>
+ *                 </sequence>
+ *               </restriction>
+ *             </complexContent>
+ *           </complexType>
+ *         </element>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */
@@ -154,47 +154,47 @@ public class PersonType {
 
 
     /**
-     * <p>Java class for anonymous complex type.
+     * <p>Java class for anonymous complex type</p>.
      * 
-     * <p>The following schema fragment specifies the expected content contained within this class.
+     * <p>The following schema fragment specifies the expected content contained within this class.</p>
      * 
-     * <pre>
-     * &lt;complexType&gt;
-     *   &lt;complexContent&gt;
-     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
-     *       &lt;sequence&gt;
-     *         &lt;element name="originalName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/&gt;
-     *         &lt;element name="alliancePartnershipName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/&gt;
-     *         &lt;element name="aliasName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/&gt;
-     *         &lt;element name="otherName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/&gt;
-     *         &lt;element name="callName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/&gt;
-     *         &lt;element name="placeOfBirth" type="{http://www.ech.ch/xmlns/eCH-0011/3}birthplaceType"/&gt;
-     *         &lt;element name="dateOfDeath" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/&gt;
-     *         &lt;element name="maritalData" type="{http://www.ech.ch/xmlns/eCH-0011/3}maritalDataType"/&gt;
-     *         &lt;element name="nationality" type="{http://www.ech.ch/xmlns/eCH-0011/3}nationalityType"/&gt;
-     *         &lt;element name="contact" minOccurs="0"&gt;
-     *           &lt;complexType&gt;
-     *             &lt;complexContent&gt;
-     *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
-     *                 &lt;sequence&gt;
-     *                   &lt;choice minOccurs="0"&gt;
-     *                     &lt;element name="personIdentification" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationType"/&gt;
-     *                     &lt;element name="personIdentificationPartner" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationPartnerType"/&gt;
-     *                     &lt;element name="partnerIdOrgnisation" type="{http://www.ech.ch/xmlns/eCH-0011/3}partnerIdOrganisationType"/&gt;
-     *                   &lt;/choice&gt;
-     *                   &lt;element name="contactAddress" type="{http://www.ech.ch/xmlns/eCH-0010/3}mailAddressType"/&gt;
-     *                 &lt;/sequence&gt;
-     *               &lt;/restriction&gt;
-     *             &lt;/complexContent&gt;
-     *           &lt;/complexType&gt;
-     *         &lt;/element&gt;
-     *         &lt;element name="languageOfCorrespondance" type="{http://www.ech.ch/xmlns/eCH-0011/3}languageType" minOccurs="0"/&gt;
-     *         &lt;element name="religion" type="{http://www.ech.ch/xmlns/eCH-0011/3}religionType"/&gt;
-     *       &lt;/sequence&gt;
-     *     &lt;/restriction&gt;
-     *   &lt;/complexContent&gt;
-     * &lt;/complexType&gt;
-     * </pre>
+     * <pre>{@code
+     * <complexType>
+     *   <complexContent>
+     *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+     *       <sequence>
+     *         <element name="originalName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/>
+     *         <element name="alliancePartnershipName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/>
+     *         <element name="aliasName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/>
+     *         <element name="otherName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/>
+     *         <element name="callName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType" minOccurs="0"/>
+     *         <element name="placeOfBirth" type="{http://www.ech.ch/xmlns/eCH-0011/3}birthplaceType"/>
+     *         <element name="dateOfDeath" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/>
+     *         <element name="maritalData" type="{http://www.ech.ch/xmlns/eCH-0011/3}maritalDataType"/>
+     *         <element name="nationality" type="{http://www.ech.ch/xmlns/eCH-0011/3}nationalityType"/>
+     *         <element name="contact" minOccurs="0">
+     *           <complexType>
+     *             <complexContent>
+     *               <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+     *                 <sequence>
+     *                   <choice minOccurs="0">
+     *                     <element name="personIdentification" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationType"/>
+     *                     <element name="personIdentificationPartner" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationPartnerType"/>
+     *                     <element name="partnerIdOrgnisation" type="{http://www.ech.ch/xmlns/eCH-0011/3}partnerIdOrganisationType"/>
+     *                   </choice>
+     *                   <element name="contactAddress" type="{http://www.ech.ch/xmlns/eCH-0010/3}mailAddressType"/>
+     *                 </sequence>
+     *               </restriction>
+     *             </complexContent>
+     *           </complexType>
+     *         </element>
+     *         <element name="languageOfCorrespondance" type="{http://www.ech.ch/xmlns/eCH-0011/3}languageType" minOccurs="0"/>
+     *         <element name="religion" type="{http://www.ech.ch/xmlns/eCH-0011/3}religionType"/>
+     *       </sequence>
+     *     </restriction>
+     *   </complexContent>
+     * </complexType>
+     * }</pre>
      * 
      * 
      */
@@ -611,26 +611,26 @@ public class PersonType {
 
 
         /**
-         * <p>Java class for anonymous complex type.
+         * <p>Java class for anonymous complex type</p>.
          * 
-         * <p>The following schema fragment specifies the expected content contained within this class.
+         * <p>The following schema fragment specifies the expected content contained within this class.</p>
          * 
-         * <pre>
-         * &lt;complexType&gt;
-         *   &lt;complexContent&gt;
-         *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
-         *       &lt;sequence&gt;
-         *         &lt;choice minOccurs="0"&gt;
-         *           &lt;element name="personIdentification" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationType"/&gt;
-         *           &lt;element name="personIdentificationPartner" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationPartnerType"/&gt;
-         *           &lt;element name="partnerIdOrgnisation" type="{http://www.ech.ch/xmlns/eCH-0011/3}partnerIdOrganisationType"/&gt;
-         *         &lt;/choice&gt;
-         *         &lt;element name="contactAddress" type="{http://www.ech.ch/xmlns/eCH-0010/3}mailAddressType"/&gt;
-         *       &lt;/sequence&gt;
-         *     &lt;/restriction&gt;
-         *   &lt;/complexContent&gt;
-         * &lt;/complexType&gt;
-         * </pre>
+         * <pre>{@code
+         * <complexType>
+         *   <complexContent>
+         *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+         *       <sequence>
+         *         <choice minOccurs="0">
+         *           <element name="personIdentification" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationType"/>
+         *           <element name="personIdentificationPartner" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationPartnerType"/>
+         *           <element name="partnerIdOrgnisation" type="{http://www.ech.ch/xmlns/eCH-0011/3}partnerIdOrganisationType"/>
+         *         </choice>
+         *         <element name="contactAddress" type="{http://www.ech.ch/xmlns/eCH-0010/3}mailAddressType"/>
+         *       </sequence>
+         *     </restriction>
+         *   </complexContent>
+         * </complexType>
+         * }</pre>
          * 
          * 
          */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/PlaceOfOriginType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/PlaceOfOriginType.java
@@ -1,37 +1,37 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
 import ch.ech.xmlns.ech_0007._3.CantonAbbreviationType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for placeOfOriginType complex type.
+ * <p>Java class for placeOfOriginType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="placeOfOriginType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="originName"&gt;
- *           &lt;simpleType&gt;
- *             &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *               &lt;maxLength value="50"/&gt;
- *             &lt;/restriction&gt;
- *           &lt;/simpleType&gt;
- *         &lt;/element&gt;
- *         &lt;element name="canton" type="{http://www.ech.ch/xmlns/eCH-0007/3}cantonAbbreviationType"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="placeOfOriginType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="originName">
+ *           <simpleType>
+ *             <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *               <maxLength value="50"/>
+ *             </restriction>
+ *           </simpleType>
+ *         </element>
+ *         <element name="canton" type="{http://www.ech.ch/xmlns/eCH-0007/3}cantonAbbreviationType"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/ReportedPersonType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/ReportedPersonType.java
@@ -1,34 +1,34 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for reportedPersonType complex type.
+ * <p>Java class for reportedPersonType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="reportedPersonType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="person" type="{http://www.ech.ch/xmlns/eCH-0011/3}personType"/&gt;
- *         &lt;element name="anyPerson" type="{http://www.ech.ch/xmlns/eCH-0011/3}anyPersonType"/&gt;
- *         &lt;choice&gt;
- *           &lt;element name="hasMainResidence" type="{http://www.ech.ch/xmlns/eCH-0011/3}mainResidenceType"/&gt;
- *           &lt;element name="hasSecondaryResidence" type="{http://www.ech.ch/xmlns/eCH-0011/3}secondaryResidenceType"/&gt;
- *           &lt;element name="hasOtherResidence" type="{http://www.ech.ch/xmlns/eCH-0011/3}otherResidenceType"/&gt;
- *         &lt;/choice&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="reportedPersonType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="person" type="{http://www.ech.ch/xmlns/eCH-0011/3}personType"/>
+ *         <element name="anyPerson" type="{http://www.ech.ch/xmlns/eCH-0011/3}anyPersonType"/>
+ *         <choice>
+ *           <element name="hasMainResidence" type="{http://www.ech.ch/xmlns/eCH-0011/3}mainResidenceType"/>
+ *           <element name="hasSecondaryResidence" type="{http://www.ech.ch/xmlns/eCH-0011/3}secondaryResidenceType"/>
+ *           <element name="hasOtherResidence" type="{http://www.ech.ch/xmlns/eCH-0011/3}otherResidenceType"/>
+ *         </choice>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/SecondaryResidenceType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/SecondaryResidenceType.java
@@ -1,47 +1,47 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
 import javax.xml.datatype.XMLGregorianCalendar;
 import ch.ech.xmlns.ech_0007._3.SwissMunicipalityType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for secondaryResidenceType complex type.
+ * <p>Java class for secondaryResidenceType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="secondaryResidenceType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="mainResidence" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/&gt;
- *         &lt;element name="secondaryResidence"&gt;
- *           &lt;complexType&gt;
- *             &lt;complexContent&gt;
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *                 &lt;sequence&gt;
- *                   &lt;element name="reportingMunicipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/&gt;
- *                   &lt;element name="arrivalDate" type="{http://www.w3.org/2001/XMLSchema}date"/&gt;
- *                   &lt;element name="comesFrom" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType"/&gt;
- *                   &lt;element name="dwellingAddress" type="{http://www.ech.ch/xmlns/eCH-0011/3}dwellingAddressType"/&gt;
- *                   &lt;element name="departureDate" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/&gt;
- *                   &lt;element name="goesTo" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType" minOccurs="0"/&gt;
- *                 &lt;/sequence&gt;
- *               &lt;/restriction&gt;
- *             &lt;/complexContent&gt;
- *           &lt;/complexType&gt;
- *         &lt;/element&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="secondaryResidenceType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="mainResidence" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/>
+ *         <element name="secondaryResidence">
+ *           <complexType>
+ *             <complexContent>
+ *               <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *                 <sequence>
+ *                   <element name="reportingMunicipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/>
+ *                   <element name="arrivalDate" type="{http://www.w3.org/2001/XMLSchema}date"/>
+ *                   <element name="comesFrom" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType"/>
+ *                   <element name="dwellingAddress" type="{http://www.ech.ch/xmlns/eCH-0011/3}dwellingAddressType"/>
+ *                   <element name="departureDate" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/>
+ *                   <element name="goesTo" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType" minOccurs="0"/>
+ *                 </sequence>
+ *               </restriction>
+ *             </complexContent>
+ *           </complexType>
+ *         </element>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */
@@ -129,26 +129,26 @@ public class SecondaryResidenceType {
 
 
     /**
-     * <p>Java class for anonymous complex type.
+     * <p>Java class for anonymous complex type</p>.
      * 
-     * <p>The following schema fragment specifies the expected content contained within this class.
+     * <p>The following schema fragment specifies the expected content contained within this class.</p>
      * 
-     * <pre>
-     * &lt;complexType&gt;
-     *   &lt;complexContent&gt;
-     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
-     *       &lt;sequence&gt;
-     *         &lt;element name="reportingMunicipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/&gt;
-     *         &lt;element name="arrivalDate" type="{http://www.w3.org/2001/XMLSchema}date"/&gt;
-     *         &lt;element name="comesFrom" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType"/&gt;
-     *         &lt;element name="dwellingAddress" type="{http://www.ech.ch/xmlns/eCH-0011/3}dwellingAddressType"/&gt;
-     *         &lt;element name="departureDate" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/&gt;
-     *         &lt;element name="goesTo" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType" minOccurs="0"/&gt;
-     *       &lt;/sequence&gt;
-     *     &lt;/restriction&gt;
-     *   &lt;/complexContent&gt;
-     * &lt;/complexType&gt;
-     * </pre>
+     * <pre>{@code
+     * <complexType>
+     *   <complexContent>
+     *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+     *       <sequence>
+     *         <element name="reportingMunicipality" type="{http://www.ech.ch/xmlns/eCH-0007/3}swissMunicipalityType"/>
+     *         <element name="arrivalDate" type="{http://www.w3.org/2001/XMLSchema}date"/>
+     *         <element name="comesFrom" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType"/>
+     *         <element name="dwellingAddress" type="{http://www.ech.ch/xmlns/eCH-0011/3}dwellingAddressType"/>
+     *         <element name="departureDate" type="{http://www.w3.org/2001/XMLSchema}date" minOccurs="0"/>
+     *         <element name="goesTo" type="{http://www.ech.ch/xmlns/eCH-0011/3}destinationType" minOccurs="0"/>
+     *       </sequence>
+     *     </restriction>
+     *   </complexContent>
+     * </complexType>
+     * }</pre>
      * 
      * 
      */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/SeparationType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/SeparationType.java
@@ -1,24 +1,25 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for separationType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="separationType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *     &lt;enumeration value="1"/&gt;
- *     &lt;enumeration value="2"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for separationType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="separationType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     <enumeration value="1"/>
+ *     <enumeration value="2"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "separationType")
@@ -35,10 +36,26 @@ public enum SeparationType {
         value = v;
     }
 
+    /**
+     * Gets the value associated to the enum constant.
+     * 
+     * @return
+     *     The value linked to the enum.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Gets the enum associated to the value passed as parameter.
+     * 
+     * @param v
+     *     The value to get the enum from.
+     * @return
+     *     The enum which corresponds to the value, if it exists.
+     * @throws IllegalArgumentException
+     *     If no value matches in the enum declaration.
+     */
     public static SeparationType fromValue(String v) {
         for (SeparationType c: SeparationType.values()) {
             if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/SwissMunicipalityWithoutBFS.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/SwissMunicipalityWithoutBFS.java
@@ -1,34 +1,34 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import ch.ech.xmlns.ech_0007._3.CantonAbbreviationType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 
 /**
- * <p>Java class for swissMunicipalityWithoutBFS complex type.
+ * <p>Java class for swissMunicipalityWithoutBFS complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="swissMunicipalityWithoutBFS"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="municipalityId" type="{http://www.ech.ch/xmlns/eCH-0007/3}municipalityIdType" minOccurs="0"/&gt;
- *         &lt;element name="municipalityName" type="{http://www.ech.ch/xmlns/eCH-0007/3}municipalityNameType"/&gt;
- *         &lt;element name="cantonAbbreviation" type="{http://www.ech.ch/xmlns/eCH-0007/3}cantonAbbreviationType" minOccurs="0"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="swissMunicipalityWithoutBFS">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="municipalityId" type="{http://www.ech.ch/xmlns/eCH-0007/3}municipalityIdType" minOccurs="0"/>
+ *         <element name="municipalityName" type="{http://www.ech.ch/xmlns/eCH-0007/3}municipalityNameType"/>
+ *         <element name="cantonAbbreviation" type="{http://www.ech.ch/xmlns/eCH-0007/3}cantonAbbreviationType" minOccurs="0"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/TypeOfHouseholdType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/TypeOfHouseholdType.java
@@ -1,26 +1,27 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for typeOfHouseholdType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="typeOfHouseholdType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *     &lt;enumeration value="1"/&gt;
- *     &lt;enumeration value="2"/&gt;
- *     &lt;enumeration value="3"/&gt;
- *     &lt;enumeration value="0"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for typeOfHouseholdType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="typeOfHouseholdType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     <enumeration value="1"/>
+ *     <enumeration value="2"/>
+ *     <enumeration value="3"/>
+ *     <enumeration value="0"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "typeOfHouseholdType")
@@ -41,10 +42,26 @@ public enum TypeOfHouseholdType {
         value = v;
     }
 
+    /**
+     * Gets the value associated to the enum constant.
+     * 
+     * @return
+     *     The value linked to the enum.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Gets the enum associated to the value passed as parameter.
+     * 
+     * @param v
+     *     The value to get the enum from.
+     * @return
+     *     The enum which corresponds to the value, if it exists.
+     * @throws IllegalArgumentException
+     *     If no value matches in the enum declaration.
+     */
     public static TypeOfHouseholdType fromValue(String v) {
         for (TypeOfHouseholdType c: TypeOfHouseholdType.values()) {
             if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/UnknownType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/UnknownType.java
@@ -1,23 +1,24 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for unknownType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="unknownType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}token"&gt;
- *     &lt;enumeration value="0"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for unknownType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="unknownType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}token">
+ *     <enumeration value="0"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "unknownType")
@@ -32,10 +33,26 @@ public enum UnknownType {
         value = v;
     }
 
+    /**
+     * Gets the value associated to the enum constant.
+     * 
+     * @return
+     *     The value linked to the enum.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Gets the enum associated to the value passed as parameter.
+     * 
+     * @param v
+     *     The value to get the enum from.
+     * @return
+     *     The enum which corresponds to the value, if it exists.
+     * @throws IllegalArgumentException
+     *     If no value matches in the enum declaration.
+     */
     public static UnknownType fromValue(String v) {
         for (UnknownType c: UnknownType.values()) {
             if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/YesNoType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/YesNoType.java
@@ -1,24 +1,25 @@
 
 package ch.ech.xmlns.ech_0011._3;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for yesNoType.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="yesNoType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *     &lt;enumeration value="0"/&gt;
- *     &lt;enumeration value="1"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * 
+ * <p>Java class for yesNoType</p>.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="yesNoType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     <enumeration value="0"/>
+ *     <enumeration value="1"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "yesNoType")
@@ -35,10 +36,26 @@ public enum YesNoType {
         value = v;
     }
 
+    /**
+     * Gets the value associated to the enum constant.
+     * 
+     * @return
+     *     The value linked to the enum.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Gets the enum associated to the value passed as parameter.
+     * 
+     * @param v
+     *     The value to get the enum from.
+     * @return
+     *     The enum which corresponds to the value, if it exists.
+     * @throws IllegalArgumentException
+     *     If no value matches in the enum declaration.
+     */
     public static YesNoType fromValue(String v) {
         for (YesNoType c: YesNoType.values()) {
             if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/package-info.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0011/_3/package-info.java
@@ -1,2 +1,2 @@
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.ech.ch/xmlns/eCH-0011/3", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://www.ech.ch/xmlns/eCH-0011/3", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package ch.ech.xmlns.ech_0011._3;

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0044/_1/DatePartiallyKnownType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0044/_1/DatePartiallyKnownType.java
@@ -1,31 +1,31 @@
 
 package ch.ech.xmlns.ech_0044._1;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
 import javax.xml.datatype.XMLGregorianCalendar;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for datePartiallyKnownType complex type.
+ * <p>Java class for datePartiallyKnownType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="datePartiallyKnownType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;choice&gt;
- *         &lt;element name="yearMonthDay" type="{http://www.w3.org/2001/XMLSchema}date"/&gt;
- *         &lt;element name="yearMonth" type="{http://www.w3.org/2001/XMLSchema}gYearMonth"/&gt;
- *         &lt;element name="year" type="{http://www.w3.org/2001/XMLSchema}gYear"/&gt;
- *       &lt;/choice&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="datePartiallyKnownType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <choice>
+ *         <element name="yearMonthDay" type="{http://www.w3.org/2001/XMLSchema}date"/>
+ *         <element name="yearMonth" type="{http://www.w3.org/2001/XMLSchema}gYearMonth"/>
+ *         <element name="year" type="{http://www.w3.org/2001/XMLSchema}gYear"/>
+ *       </choice>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0044/_1/NamedPersonIdType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0044/_1/NamedPersonIdType.java
@@ -1,39 +1,39 @@
 
 package ch.ech.xmlns.ech_0044._1;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlSeeAlso;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlSeeAlso;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 
 /**
- * <p>Java class for namedPersonIdType complex type.
+ * <p>Java class for namedPersonIdType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="namedPersonIdType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="personIdCategory" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdCategoryType"/&gt;
- *         &lt;element name="personId"&gt;
- *           &lt;simpleType&gt;
- *             &lt;restriction base="{http://www.w3.org/2001/XMLSchema}token"&gt;
- *               &lt;maxLength value="20"/&gt;
- *             &lt;/restriction&gt;
- *           &lt;/simpleType&gt;
- *         &lt;/element&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="namedPersonIdType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="personIdCategory" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdCategoryType"/>
+ *         <element name="personId">
+ *           <simpleType>
+ *             <restriction base="{http://www.w3.org/2001/XMLSchema}token">
+ *               <maxLength value="20"/>
+ *             </restriction>
+ *           </simpleType>
+ *         </element>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0044/_1/ObjectFactory.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0044/_1/ObjectFactory.java
@@ -1,14 +1,14 @@
 
 package ch.ech.xmlns.ech_0044._1;
 
-import javax.xml.bind.annotation.XmlRegistry;
+import jakarta.xml.bind.annotation.XmlRegistry;
 
 
 /**
  * This object contains factory methods for each 
  * Java content interface and Java element interface 
  * generated in the ch.ech.xmlns.ech_0044._1 package. 
- * <p>An ObjectFactory allows you to programatically 
+ * <p>An ObjectFactory allows you to programmatically 
  * construct new instances of the Java representation 
  * for XML content. The Java representation of XML 
  * content can consist of schema derived interfaces 
@@ -32,6 +32,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link PersonIdentificationPartnerType }
      * 
+     * @return
+     *     the new instance of {@link PersonIdentificationPartnerType }
      */
     public PersonIdentificationPartnerType createPersonIdentificationPartnerType() {
         return new PersonIdentificationPartnerType();
@@ -40,6 +42,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link PersonIdentificationType }
      * 
+     * @return
+     *     the new instance of {@link PersonIdentificationType }
      */
     public PersonIdentificationType createPersonIdentificationType() {
         return new PersonIdentificationType();
@@ -48,6 +52,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link PersonIdentificationRoot }
      * 
+     * @return
+     *     the new instance of {@link PersonIdentificationRoot }
      */
     public PersonIdentificationRoot createPersonIdentificationRoot() {
         return new PersonIdentificationRoot();
@@ -56,6 +62,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link NamedPersonIdType }
      * 
+     * @return
+     *     the new instance of {@link NamedPersonIdType }
      */
     public NamedPersonIdType createNamedPersonIdType() {
         return new NamedPersonIdType();
@@ -64,6 +72,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link DatePartiallyKnownType }
      * 
+     * @return
+     *     the new instance of {@link DatePartiallyKnownType }
      */
     public DatePartiallyKnownType createDatePartiallyKnownType() {
         return new DatePartiallyKnownType();
@@ -72,6 +82,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link PersonIdentificationPartnerType.OtherPersonId }
      * 
+     * @return
+     *     the new instance of {@link PersonIdentificationPartnerType.OtherPersonId }
      */
     public PersonIdentificationPartnerType.OtherPersonId createPersonIdentificationPartnerTypeOtherPersonId() {
         return new PersonIdentificationPartnerType.OtherPersonId();
@@ -80,6 +92,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link PersonIdentificationType.OtherPersonId }
      * 
+     * @return
+     *     the new instance of {@link PersonIdentificationType.OtherPersonId }
      */
     public PersonIdentificationType.OtherPersonId createPersonIdentificationTypeOtherPersonId() {
         return new PersonIdentificationType.OtherPersonId();

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0044/_1/PersonIdentificationPartnerType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0044/_1/PersonIdentificationPartnerType.java
@@ -3,44 +3,44 @@ package ch.ech.xmlns.ech_0044._1;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 
 /**
- * <p>Java class for personIdentificationPartnerType complex type.
+ * <p>Java class for personIdentificationPartnerType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="personIdentificationPartnerType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="vn" type="{http://www.ech.ch/xmlns/eCH-0044/1}vnType" minOccurs="0"/&gt;
- *         &lt;element name="localPersonId" type="{http://www.ech.ch/xmlns/eCH-0044/1}namedPersonIdType"/&gt;
- *         &lt;element name="OtherPersonId" maxOccurs="unbounded" minOccurs="0"&gt;
- *           &lt;complexType&gt;
- *             &lt;complexContent&gt;
- *               &lt;extension base="{http://www.ech.ch/xmlns/eCH-0044/1}namedPersonIdType"&gt;
- *               &lt;/extension&gt;
- *             &lt;/complexContent&gt;
- *           &lt;/complexType&gt;
- *         &lt;/element&gt;
- *         &lt;element name="officialName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType"/&gt;
- *         &lt;element name="firstName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType"/&gt;
- *         &lt;element name="sex" type="{http://www.ech.ch/xmlns/eCH-0044/1}sexType" minOccurs="0"/&gt;
- *         &lt;element name="dateOfBirth" type="{http://www.ech.ch/xmlns/eCH-0044/1}datePartiallyKnownType" minOccurs="0"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="personIdentificationPartnerType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="vn" type="{http://www.ech.ch/xmlns/eCH-0044/1}vnType" minOccurs="0"/>
+ *         <element name="localPersonId" type="{http://www.ech.ch/xmlns/eCH-0044/1}namedPersonIdType"/>
+ *         <element name="OtherPersonId" maxOccurs="unbounded" minOccurs="0">
+ *           <complexType>
+ *             <complexContent>
+ *               <extension base="{http://www.ech.ch/xmlns/eCH-0044/1}namedPersonIdType">
+ *               </extension>
+ *             </complexContent>
+ *           </complexType>
+ *         </element>
+ *         <element name="officialName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType"/>
+ *         <element name="firstName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType"/>
+ *         <element name="sex" type="{http://www.ech.ch/xmlns/eCH-0044/1}sexType" minOccurs="0"/>
+ *         <element name="dateOfBirth" type="{http://www.ech.ch/xmlns/eCH-0044/1}datePartiallyKnownType" minOccurs="0"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */
@@ -133,28 +133,31 @@ public class PersonIdentificationPartnerType {
     /**
      * Gets the value of the otherPersonId property.
      * 
-     * <p>
-     * This accessor method returns a reference to the live list,
+     * <p>This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
-     * This is why there is not a <CODE>set</CODE> method for the otherPersonId property.
+     * This is why there is not a <CODE>set</CODE> method for the otherPersonId property.</p>
      * 
      * <p>
      * For example, to add a new item, do as follows:
+     * </p>
      * <pre>
-     *    getOtherPersonId().add(newItem);
+     * getOtherPersonId().add(newItem);
      * </pre>
      * 
      * 
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link PersonIdentificationPartnerType.OtherPersonId }
+     * </p>
      * 
      * 
+     * @return
+     *     The value of the otherPersonId property.
      */
     public List<PersonIdentificationPartnerType.OtherPersonId> getOtherPersonId() {
         if (otherPersonId == null) {
-            otherPersonId = new ArrayList<PersonIdentificationPartnerType.OtherPersonId>();
+            otherPersonId = new ArrayList<>();
         }
         return this.otherPersonId;
     }
@@ -301,18 +304,18 @@ public class PersonIdentificationPartnerType {
 
 
     /**
-     * <p>Java class for anonymous complex type.
+     * <p>Java class for anonymous complex type</p>.
      * 
-     * <p>The following schema fragment specifies the expected content contained within this class.
+     * <p>The following schema fragment specifies the expected content contained within this class.</p>
      * 
-     * <pre>
-     * &lt;complexType&gt;
-     *   &lt;complexContent&gt;
-     *     &lt;extension base="{http://www.ech.ch/xmlns/eCH-0044/1}namedPersonIdType"&gt;
-     *     &lt;/extension&gt;
-     *   &lt;/complexContent&gt;
-     * &lt;/complexType&gt;
-     * </pre>
+     * <pre>{@code
+     * <complexType>
+     *   <complexContent>
+     *     <extension base="{http://www.ech.ch/xmlns/eCH-0044/1}namedPersonIdType">
+     *     </extension>
+     *   </complexContent>
+     * </complexType>
+     * }</pre>
      * 
      * 
      */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0044/_1/PersonIdentificationRoot.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0044/_1/PersonIdentificationRoot.java
@@ -1,29 +1,29 @@
 
 package ch.ech.xmlns.ech_0044._1;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for anonymous complex type.
+ * <p>Java class for anonymous complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="personIdentification" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationType"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType>
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="personIdentification" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationType"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0044/_1/PersonIdentificationType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0044/_1/PersonIdentificationType.java
@@ -3,45 +3,45 @@ package ch.ech.xmlns.ech_0044._1;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 
 /**
- * <p>Java class for personIdentificationType complex type.
+ * <p>Java class for personIdentificationType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="personIdentificationType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="vn" type="{http://www.ech.ch/xmlns/eCH-0044/1}vnType" minOccurs="0"/&gt;
- *         &lt;element name="localPersonId" type="{http://www.ech.ch/xmlns/eCH-0044/1}namedPersonIdType"/&gt;
- *         &lt;element name="OtherPersonId" maxOccurs="unbounded" minOccurs="0"&gt;
- *           &lt;complexType&gt;
- *             &lt;complexContent&gt;
- *               &lt;extension base="{http://www.ech.ch/xmlns/eCH-0044/1}namedPersonIdType"&gt;
- *               &lt;/extension&gt;
- *             &lt;/complexContent&gt;
- *           &lt;/complexType&gt;
- *         &lt;/element&gt;
- *         &lt;element name="EuPersonId" type="{http://www.ech.ch/xmlns/eCH-0044/1}namedPersonIdType" maxOccurs="unbounded" minOccurs="0"/&gt;
- *         &lt;element name="officialName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType"/&gt;
- *         &lt;element name="firstName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType"/&gt;
- *         &lt;element name="sex" type="{http://www.ech.ch/xmlns/eCH-0044/1}sexType"/&gt;
- *         &lt;element name="dateOfBirth" type="{http://www.ech.ch/xmlns/eCH-0044/1}datePartiallyKnownType"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="personIdentificationType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="vn" type="{http://www.ech.ch/xmlns/eCH-0044/1}vnType" minOccurs="0"/>
+ *         <element name="localPersonId" type="{http://www.ech.ch/xmlns/eCH-0044/1}namedPersonIdType"/>
+ *         <element name="OtherPersonId" maxOccurs="unbounded" minOccurs="0">
+ *           <complexType>
+ *             <complexContent>
+ *               <extension base="{http://www.ech.ch/xmlns/eCH-0044/1}namedPersonIdType">
+ *               </extension>
+ *             </complexContent>
+ *           </complexType>
+ *         </element>
+ *         <element name="EuPersonId" type="{http://www.ech.ch/xmlns/eCH-0044/1}namedPersonIdType" maxOccurs="unbounded" minOccurs="0"/>
+ *         <element name="officialName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType"/>
+ *         <element name="firstName" type="{http://www.ech.ch/xmlns/eCH-0044/1}baseNameType"/>
+ *         <element name="sex" type="{http://www.ech.ch/xmlns/eCH-0044/1}sexType"/>
+ *         <element name="dateOfBirth" type="{http://www.ech.ch/xmlns/eCH-0044/1}datePartiallyKnownType"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */
@@ -139,28 +139,31 @@ public class PersonIdentificationType {
     /**
      * Gets the value of the otherPersonId property.
      * 
-     * <p>
-     * This accessor method returns a reference to the live list,
+     * <p>This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
-     * This is why there is not a <CODE>set</CODE> method for the otherPersonId property.
+     * This is why there is not a <CODE>set</CODE> method for the otherPersonId property.</p>
      * 
      * <p>
      * For example, to add a new item, do as follows:
+     * </p>
      * <pre>
-     *    getOtherPersonId().add(newItem);
+     * getOtherPersonId().add(newItem);
      * </pre>
      * 
      * 
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link PersonIdentificationType.OtherPersonId }
+     * </p>
      * 
      * 
+     * @return
+     *     The value of the otherPersonId property.
      */
     public List<PersonIdentificationType.OtherPersonId> getOtherPersonId() {
         if (otherPersonId == null) {
-            otherPersonId = new ArrayList<PersonIdentificationType.OtherPersonId>();
+            otherPersonId = new ArrayList<>();
         }
         return this.otherPersonId;
     }
@@ -176,28 +179,31 @@ public class PersonIdentificationType {
     /**
      * Gets the value of the euPersonId property.
      * 
-     * <p>
-     * This accessor method returns a reference to the live list,
+     * <p>This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
-     * This is why there is not a <CODE>set</CODE> method for the euPersonId property.
+     * This is why there is not a <CODE>set</CODE> method for the euPersonId property.</p>
      * 
      * <p>
      * For example, to add a new item, do as follows:
+     * </p>
      * <pre>
-     *    getEuPersonId().add(newItem);
+     * getEuPersonId().add(newItem);
      * </pre>
      * 
      * 
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link NamedPersonIdType }
+     * </p>
      * 
      * 
+     * @return
+     *     The value of the euPersonId property.
      */
     public List<NamedPersonIdType> getEuPersonId() {
         if (euPersonId == null) {
-            euPersonId = new ArrayList<NamedPersonIdType>();
+            euPersonId = new ArrayList<>();
         }
         return this.euPersonId;
     }
@@ -350,18 +356,18 @@ public class PersonIdentificationType {
 
 
     /**
-     * <p>Java class for anonymous complex type.
+     * <p>Java class for anonymous complex type</p>.
      * 
-     * <p>The following schema fragment specifies the expected content contained within this class.
+     * <p>The following schema fragment specifies the expected content contained within this class.</p>
      * 
-     * <pre>
-     * &lt;complexType&gt;
-     *   &lt;complexContent&gt;
-     *     &lt;extension base="{http://www.ech.ch/xmlns/eCH-0044/1}namedPersonIdType"&gt;
-     *     &lt;/extension&gt;
-     *   &lt;/complexContent&gt;
-     * &lt;/complexType&gt;
-     * </pre>
+     * <pre>{@code
+     * <complexType>
+     *   <complexContent>
+     *     <extension base="{http://www.ech.ch/xmlns/eCH-0044/1}namedPersonIdType">
+     *     </extension>
+     *   </complexContent>
+     * </complexType>
+     * }</pre>
      * 
      * 
      */

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0044/_1/SexType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0044/_1/SexType.java
@@ -1,24 +1,23 @@
 
 package ch.ech.xmlns.ech_0044._1;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for sexType.
+ * <p>Java class for sexType</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;simpleType name="sexType"&gt;
- *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *     &lt;enumeration value="1"/&gt;
- *     &lt;enumeration value="2"/&gt;
- *   &lt;/restriction&gt;
- * &lt;/simpleType&gt;
- * </pre>
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>{@code
+ * <simpleType name="sexType">
+ *   <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *     <enumeration value="1"/>
+ *     <enumeration value="2"/>
+ *   </restriction>
+ * </simpleType>
+ * }</pre>
  * 
  */
 @XmlType(name = "sexType")
@@ -35,10 +34,26 @@ public enum SexType {
         value = v;
     }
 
+    /**
+     * Gets the value associated to the enum constant.
+     * 
+     * @return
+     *     The value linked to the enum.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Gets the enum associated to the value passed as parameter.
+     * 
+     * @param v
+     *     The value to get the enum from.
+     * @return
+     *     The enum which corresponds to the value, if it exists.
+     * @throws IllegalArgumentException
+     *     If no value matches in the enum declaration.
+     */
     public static SexType fromValue(String v) {
         for (SexType c: SexType.values()) {
             if (c.value.equals(v)) {

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0044/_1/package-info.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0044/_1/package-info.java
@@ -1,2 +1,2 @@
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.ech.ch/xmlns/eCH-0044/1", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://www.ech.ch/xmlns/eCH-0044/1", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package ch.ech.xmlns.ech_0044._1;

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0099/_1/Delivery.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0099/_1/Delivery.java
@@ -3,38 +3,38 @@ package ch.ech.xmlns.ech_0099._1;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
 import ch.ech.xmlns.ech_0011._3.ReportedPersonType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for anonymous complex type.
+ * <p>Java class for anonymous complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="reportedPerson" type="{http://www.ech.ch/xmlns/eCH-0011/3}reportedPersonType" maxOccurs="unbounded"/&gt;
- *       &lt;/sequence&gt;
- *       &lt;attribute name="version" use="required"&gt;
- *         &lt;simpleType&gt;
- *           &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *             &lt;enumeration value="1.1"/&gt;
- *           &lt;/restriction&gt;
- *         &lt;/simpleType&gt;
- *       &lt;/attribute&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType>
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="reportedPerson" type="{http://www.ech.ch/xmlns/eCH-0011/3}reportedPersonType" maxOccurs="unbounded"/>
+ *       </sequence>
+ *       <attribute name="version" use="required">
+ *         <simpleType>
+ *           <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *             <enumeration value="1.1"/>
+ *           </restriction>
+ *         </simpleType>
+ *       </attribute>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */
@@ -47,34 +47,41 @@ public class Delivery {
 
     @XmlElement(required = true)
     protected List<ReportedPersonType> reportedPerson;
+    /**
+     * Versionsnummer des XML Schemas, welches dieses Element beschreibt.
+     * 
+     */
     @XmlAttribute(name = "version", required = true)
     protected String version;
 
     /**
      * Gets the value of the reportedPerson property.
      * 
-     * <p>
-     * This accessor method returns a reference to the live list,
+     * <p>This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
-     * This is why there is not a <CODE>set</CODE> method for the reportedPerson property.
+     * This is why there is not a <CODE>set</CODE> method for the reportedPerson property.</p>
      * 
      * <p>
      * For example, to add a new item, do as follows:
+     * </p>
      * <pre>
-     *    getReportedPerson().add(newItem);
+     * getReportedPerson().add(newItem);
      * </pre>
      * 
      * 
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link ReportedPersonType }
+     * </p>
      * 
      * 
+     * @return
+     *     The value of the reportedPerson property.
      */
     public List<ReportedPersonType> getReportedPerson() {
         if (reportedPerson == null) {
-            reportedPerson = new ArrayList<ReportedPersonType>();
+            reportedPerson = new ArrayList<>();
         }
         return this.reportedPerson;
     }
@@ -88,7 +95,7 @@ public class Delivery {
     }
 
     /**
-     * Gets the value of the version property.
+     * Versionsnummer des XML Schemas, welches dieses Element beschreibt.
      * 
      * @return
      *     possible object is
@@ -106,6 +113,7 @@ public class Delivery {
      *     allowed object is
      *     {@link String }
      *     
+     * @see #getVersion()
      */
     public void setVersion(String value) {
         this.version = value;

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0099/_1/ErrorInfoType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0099/_1/ErrorInfoType.java
@@ -1,29 +1,29 @@
 
 package ch.ech.xmlns.ech_0099._1;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for errorInfoType complex type.
+ * <p>Java class for errorInfoType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="errorInfoType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="code" type="{http://www.w3.org/2001/XMLSchema}string"/&gt;
- *         &lt;element name="text" type="{http://www.w3.org/2001/XMLSchema}string"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="errorInfoType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="code" type="{http://www.w3.org/2001/XMLSchema}string"/>
+ *         <element name="text" type="{http://www.w3.org/2001/XMLSchema}string"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */
@@ -34,13 +34,24 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class ErrorInfoType {
 
+    /**
+     * Nummerischer Code des Fehlers. Der Wertebereich und die Bedeutung 
+     *             dieser Codes sind in einem anderen Dokument spezifiziert.
+     * 
+     */
     @XmlElement(required = true)
     protected String code;
+    /**
+     * Textuelle Beschreibung des Fehlers. Die Bedeutung ist in einem anderen 
+     *             Dokument spezifiziert.
+     * 
+     */
     @XmlElement(required = true)
     protected String text;
 
     /**
-     * Gets the value of the code property.
+     * Nummerischer Code des Fehlers. Der Wertebereich und die Bedeutung 
+     *             dieser Codes sind in einem anderen Dokument spezifiziert.
      * 
      * @return
      *     possible object is
@@ -58,6 +69,7 @@ public class ErrorInfoType {
      *     allowed object is
      *     {@link String }
      *     
+     * @see #getCode()
      */
     public void setCode(String value) {
         this.code = value;
@@ -68,7 +80,8 @@ public class ErrorInfoType {
     }
 
     /**
-     * Gets the value of the text property.
+     * Textuelle Beschreibung des Fehlers. Die Bedeutung ist in einem anderen 
+     *             Dokument spezifiziert.
      * 
      * @return
      *     possible object is
@@ -86,6 +99,7 @@ public class ErrorInfoType {
      *     allowed object is
      *     {@link String }
      *     
+     * @see #getText()
      */
     public void setText(String value) {
         this.text = value;

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0099/_1/ObjectFactory.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0099/_1/ObjectFactory.java
@@ -1,17 +1,17 @@
 
 package ch.ech.xmlns.ech_0099._1;
 
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.annotation.XmlElementDecl;
-import javax.xml.bind.annotation.XmlRegistry;
 import javax.xml.namespace.QName;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.annotation.XmlElementDecl;
+import jakarta.xml.bind.annotation.XmlRegistry;
 
 
 /**
  * This object contains factory methods for each 
  * Java content interface and Java element interface 
  * generated in the ch.ech.xmlns.ech_0099._1 package. 
- * <p>An ObjectFactory allows you to programatically 
+ * <p>An ObjectFactory allows you to programmatically 
  * construct new instances of the Java representation 
  * for XML content. The Java representation of XML 
  * content can consist of schema derived interfaces 
@@ -24,7 +24,7 @@ import javax.xml.namespace.QName;
 @XmlRegistry
 public class ObjectFactory {
 
-    private final static QName _ValidationReport_QNAME = new QName("http://www.ech.ch/xmlns/eCH-0099/1", "validationReport");
+    private static final QName _ValidationReport_QNAME = new QName("http://www.ech.ch/xmlns/eCH-0099/1", "validationReport");
 
     /**
      * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: ch.ech.xmlns.ech_0099._1
@@ -36,6 +36,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link ValidationReportType }
      * 
+     * @return
+     *     the new instance of {@link ValidationReportType }
      */
     public ValidationReportType createValidationReportType() {
         return new ValidationReportType();
@@ -44,6 +46,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link Delivery }
      * 
+     * @return
+     *     the new instance of {@link Delivery }
      */
     public Delivery createDelivery() {
         return new Delivery();
@@ -52,6 +56,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link Receipt }
      * 
+     * @return
+     *     the new instance of {@link Receipt }
      */
     public Receipt createReceipt() {
         return new Receipt();
@@ -60,6 +66,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link ErrorInfoType }
      * 
+     * @return
+     *     the new instance of {@link ErrorInfoType }
      */
     public ErrorInfoType createErrorInfoType() {
         return new ErrorInfoType();
@@ -68,6 +76,8 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link ValidationReportType.PersonError }
      * 
+     * @return
+     *     the new instance of {@link ValidationReportType.PersonError }
      */
     public ValidationReportType.PersonError createValidationReportTypePersonError() {
         return new ValidationReportType.PersonError();
@@ -76,18 +86,24 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link ValidationReportType.EgidAttribution }
      * 
+     * @return
+     *     the new instance of {@link ValidationReportType.EgidAttribution }
      */
     public ValidationReportType.EgidAttribution createValidationReportTypeEgidAttribution() {
         return new ValidationReportType.EgidAttribution();
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ValidationReportType }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link ValidationReportType }{@code >}
      * 
+     * @param value
+     *     Java instance representing xml element's value.
+     * @return
+     *     the new instance of {@link JAXBElement }{@code <}{@link ValidationReportType }{@code >}
      */
     @XmlElementDecl(namespace = "http://www.ech.ch/xmlns/eCH-0099/1", name = "validationReport")
     public JAXBElement<ValidationReportType> createValidationReport(ValidationReportType value) {
-        return new JAXBElement<ValidationReportType>(_ValidationReport_QNAME, ValidationReportType.class, null, value);
+        return new JAXBElement<>(_ValidationReport_QNAME, ValidationReportType.class, null, value);
     }
 
 }

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0099/_1/Receipt.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0099/_1/Receipt.java
@@ -1,39 +1,39 @@
 
 package ch.ech.xmlns.ech_0099._1;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
 import javax.xml.datatype.XMLGregorianCalendar;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * <p>Java class for anonymous complex type.
+ * <p>Java class for anonymous complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="eventTime" type="{http://www.w3.org/2001/XMLSchema}date"/&gt;
- *       &lt;/sequence&gt;
- *       &lt;attribute name="version" use="required"&gt;
- *         &lt;simpleType&gt;
- *           &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *             &lt;enumeration value="1.0"/&gt;
- *           &lt;/restriction&gt;
- *         &lt;/simpleType&gt;
- *       &lt;/attribute&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType>
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="eventTime" type="{http://www.w3.org/2001/XMLSchema}date"/>
+ *       </sequence>
+ *       <attribute name="version" use="required">
+ *         <simpleType>
+ *           <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *             <enumeration value="1.0"/>
+ *           </restriction>
+ *         </simpleType>
+ *       </attribute>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */
@@ -44,14 +44,24 @@ import javax.xml.datatype.XMLGregorianCalendar;
 @XmlRootElement(name = "receipt")
 public class Receipt {
 
+    /**
+     * Zeitstempfel. Gibt den Zeitpunkt an, wann das angelieferte XML Dokument
+     *               in den Verarbeitungsprozess übertragen wurde.
+     * 
+     */
     @XmlElement(required = true)
     @XmlSchemaType(name = "date")
     protected XMLGregorianCalendar eventTime;
+    /**
+     * Versionsnummer des XML Schemas, welches dieses Element beschreibt.
+     * 
+     */
     @XmlAttribute(name = "version", required = true)
     protected String version;
 
     /**
-     * Gets the value of the eventTime property.
+     * Zeitstempfel. Gibt den Zeitpunkt an, wann das angelieferte XML Dokument
+     *               in den Verarbeitungsprozess übertragen wurde.
      * 
      * @return
      *     possible object is
@@ -69,6 +79,7 @@ public class Receipt {
      *     allowed object is
      *     {@link XMLGregorianCalendar }
      *     
+     * @see #getEventTime()
      */
     public void setEventTime(XMLGregorianCalendar value) {
         this.eventTime = value;
@@ -79,7 +90,7 @@ public class Receipt {
     }
 
     /**
-     * Gets the value of the version property.
+     * Versionsnummer des XML Schemas, welches dieses Element beschreibt.
      * 
      * @return
      *     possible object is
@@ -97,6 +108,7 @@ public class Receipt {
      *     allowed object is
      *     {@link String }
      *     
+     * @see #getVersion()
      */
     public void setVersion(String value) {
         this.version = value;

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0099/_1/ValidationReportType.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0099/_1/ValidationReportType.java
@@ -3,67 +3,65 @@ package ch.ech.xmlns.ech_0099._1;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
 import ch.ech.xmlns.ech_0044._1.PersonIdentificationType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**
- * 
- *         Elemente dieses Typs sind die vom Bundesamt für Statistik im Fall der Validierung
+ * Elemente dieses Typs sind die vom Bundesamt für Statistik im Fall der Validierung
  *         sowie Lieferung an die Statistik gelieferten Resultate.
- *       
  * 
- * <p>Java class for validationReportType complex type.
+ * <p>Java class for validationReportType complex type</p>.
  * 
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
  * 
- * <pre>
- * &lt;complexType name="validationReportType"&gt;
- *   &lt;complexContent&gt;
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="generalError" type="{http://www.ech.ch/xmlns/eCH-0099/1}errorInfoType" maxOccurs="unbounded" minOccurs="0"/&gt;
- *         &lt;element name="personError" maxOccurs="unbounded" minOccurs="0"&gt;
- *           &lt;complexType&gt;
- *             &lt;complexContent&gt;
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *                 &lt;sequence&gt;
- *                   &lt;element name="personIdentification" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationType"/&gt;
- *                   &lt;element name="errorInfo" type="{http://www.ech.ch/xmlns/eCH-0099/1}errorInfoType" maxOccurs="unbounded"/&gt;
- *                 &lt;/sequence&gt;
- *               &lt;/restriction&gt;
- *             &lt;/complexContent&gt;
- *           &lt;/complexType&gt;
- *         &lt;/element&gt;
- *         &lt;element name="egidAttribution" maxOccurs="unbounded" minOccurs="0"&gt;
- *           &lt;complexType&gt;
- *             &lt;complexContent&gt;
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
- *                 &lt;sequence&gt;
- *                   &lt;element name="personIdentification" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationType"/&gt;
- *                   &lt;element name="EGID" type="{http://www.ech.ch/xmlns/eCH-0011/3}EGIDType"/&gt;
- *                 &lt;/sequence&gt;
- *               &lt;/restriction&gt;
- *             &lt;/complexContent&gt;
- *           &lt;/complexType&gt;
- *         &lt;/element&gt;
- *       &lt;/sequence&gt;
- *       &lt;attribute name="version" use="required"&gt;
- *         &lt;simpleType&gt;
- *           &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string"&gt;
- *             &lt;enumeration value="1.0"/&gt;
- *           &lt;/restriction&gt;
- *         &lt;/simpleType&gt;
- *       &lt;/attribute&gt;
- *     &lt;/restriction&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
+ * <pre>{@code
+ * <complexType name="validationReportType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="generalError" type="{http://www.ech.ch/xmlns/eCH-0099/1}errorInfoType" maxOccurs="unbounded" minOccurs="0"/>
+ *         <element name="personError" maxOccurs="unbounded" minOccurs="0">
+ *           <complexType>
+ *             <complexContent>
+ *               <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *                 <sequence>
+ *                   <element name="personIdentification" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationType"/>
+ *                   <element name="errorInfo" type="{http://www.ech.ch/xmlns/eCH-0099/1}errorInfoType" maxOccurs="unbounded"/>
+ *                 </sequence>
+ *               </restriction>
+ *             </complexContent>
+ *           </complexType>
+ *         </element>
+ *         <element name="egidAttribution" maxOccurs="unbounded" minOccurs="0">
+ *           <complexType>
+ *             <complexContent>
+ *               <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *                 <sequence>
+ *                   <element name="personIdentification" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationType"/>
+ *                   <element name="EGID" type="{http://www.ech.ch/xmlns/eCH-0011/3}EGIDType"/>
+ *                 </sequence>
+ *               </restriction>
+ *             </complexContent>
+ *           </complexType>
+ *         </element>
+ *       </sequence>
+ *       <attribute name="version" use="required">
+ *         <simpleType>
+ *           <restriction base="{http://www.w3.org/2001/XMLSchema}string">
+ *             <enumeration value="1.0"/>
+ *           </restriction>
+ *         </simpleType>
+ *       </attribute>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * }</pre>
  * 
  * 
  */
@@ -75,37 +73,65 @@ import ch.ech.xmlns.ech_0044._1.PersonIdentificationType;
 })
 public class ValidationReportType {
 
+    /**
+     * Auflistung der allgemeinen Fehler, die in dem angelieferten XML 
+     *             Dokument gefunden wurden. Allgemeine Fehler beziehen sich nicht
+     *             auf eine Person, sondern auf das angelieferte XML Dokument im Ganzen.
+     * 
+     */
     protected List<ErrorInfoType> generalError;
+    /**
+     * Auflistung der personenbezogenen Fehler, die in dem angelieferten XML 
+     *             Dokument gefunden wurden. Personenbezogene Fehler beziehen sich auf
+     *             eine konkrete Person.
+     * 
+     */
     protected List<ValidationReportType.PersonError> personError;
+    /**
+     * Zuteilung eines Gebäudeidentifikators (EGID) zu einer Person, deren
+     *             Daten in dem angelieferten XML Dokument gefunden wurden.
+     * 
+     */
     protected List<ValidationReportType.EgidAttribution> egidAttribution;
+    /**
+     * Versionsnummer des XML Schemas, welches dieses Element beschreibt.
+     * 
+     */
     @XmlAttribute(name = "version", required = true)
     protected String version;
 
     /**
+     * Auflistung der allgemeinen Fehler, die in dem angelieferten XML 
+     *             Dokument gefunden wurden. Allgemeine Fehler beziehen sich nicht
+     *             auf eine Person, sondern auf das angelieferte XML Dokument im Ganzen.
+     * 
      * Gets the value of the generalError property.
      * 
-     * <p>
-     * This accessor method returns a reference to the live list,
+     * <p>This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
-     * This is why there is not a <CODE>set</CODE> method for the generalError property.
+     * This is why there is not a <CODE>set</CODE> method for the generalError property.</p>
      * 
      * <p>
      * For example, to add a new item, do as follows:
+     * </p>
      * <pre>
-     *    getGeneralError().add(newItem);
+     * getGeneralError().add(newItem);
      * </pre>
      * 
      * 
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link ErrorInfoType }
+     * </p>
      * 
      * 
+     * @return
+     *     The value of the generalError property.
      */
     public List<ErrorInfoType> getGeneralError() {
         if (generalError == null) {
-            generalError = new ArrayList<ErrorInfoType>();
+            generalError = new ArrayList<>();
         }
         return this.generalError;
     }
@@ -119,30 +145,37 @@ public class ValidationReportType {
     }
 
     /**
+     * Auflistung der personenbezogenen Fehler, die in dem angelieferten XML 
+     *             Dokument gefunden wurden. Personenbezogene Fehler beziehen sich auf
+     *             eine konkrete Person.
+     * 
      * Gets the value of the personError property.
      * 
-     * <p>
-     * This accessor method returns a reference to the live list,
+     * <p>This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
-     * This is why there is not a <CODE>set</CODE> method for the personError property.
+     * This is why there is not a <CODE>set</CODE> method for the personError property.</p>
      * 
      * <p>
      * For example, to add a new item, do as follows:
+     * </p>
      * <pre>
-     *    getPersonError().add(newItem);
+     * getPersonError().add(newItem);
      * </pre>
      * 
      * 
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link ValidationReportType.PersonError }
+     * </p>
      * 
      * 
+     * @return
+     *     The value of the personError property.
      */
     public List<ValidationReportType.PersonError> getPersonError() {
         if (personError == null) {
-            personError = new ArrayList<ValidationReportType.PersonError>();
+            personError = new ArrayList<>();
         }
         return this.personError;
     }
@@ -156,30 +189,36 @@ public class ValidationReportType {
     }
 
     /**
+     * Zuteilung eines Gebäudeidentifikators (EGID) zu einer Person, deren
+     *             Daten in dem angelieferten XML Dokument gefunden wurden.
+     * 
      * Gets the value of the egidAttribution property.
      * 
-     * <p>
-     * This accessor method returns a reference to the live list,
+     * <p>This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
-     * This is why there is not a <CODE>set</CODE> method for the egidAttribution property.
+     * This is why there is not a <CODE>set</CODE> method for the egidAttribution property.</p>
      * 
      * <p>
      * For example, to add a new item, do as follows:
+     * </p>
      * <pre>
-     *    getEgidAttribution().add(newItem);
+     * getEgidAttribution().add(newItem);
      * </pre>
      * 
      * 
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link ValidationReportType.EgidAttribution }
+     * </p>
      * 
      * 
+     * @return
+     *     The value of the egidAttribution property.
      */
     public List<ValidationReportType.EgidAttribution> getEgidAttribution() {
         if (egidAttribution == null) {
-            egidAttribution = new ArrayList<ValidationReportType.EgidAttribution>();
+            egidAttribution = new ArrayList<>();
         }
         return this.egidAttribution;
     }
@@ -193,7 +232,7 @@ public class ValidationReportType {
     }
 
     /**
-     * Gets the value of the version property.
+     * Versionsnummer des XML Schemas, welches dieses Element beschreibt.
      * 
      * @return
      *     possible object is
@@ -211,6 +250,7 @@ public class ValidationReportType {
      *     allowed object is
      *     {@link String }
      *     
+     * @see #getVersion()
      */
     public void setVersion(String value) {
         this.version = value;
@@ -240,22 +280,22 @@ public class ValidationReportType {
 
 
     /**
-     * <p>Java class for anonymous complex type.
+     * <p>Java class for anonymous complex type</p>.
      * 
-     * <p>The following schema fragment specifies the expected content contained within this class.
+     * <p>The following schema fragment specifies the expected content contained within this class.</p>
      * 
-     * <pre>
-     * &lt;complexType&gt;
-     *   &lt;complexContent&gt;
-     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
-     *       &lt;sequence&gt;
-     *         &lt;element name="personIdentification" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationType"/&gt;
-     *         &lt;element name="EGID" type="{http://www.ech.ch/xmlns/eCH-0011/3}EGIDType"/&gt;
-     *       &lt;/sequence&gt;
-     *     &lt;/restriction&gt;
-     *   &lt;/complexContent&gt;
-     * &lt;/complexType&gt;
-     * </pre>
+     * <pre>{@code
+     * <complexType>
+     *   <complexContent>
+     *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+     *       <sequence>
+     *         <element name="personIdentification" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationType"/>
+     *         <element name="EGID" type="{http://www.ech.ch/xmlns/eCH-0011/3}EGIDType"/>
+     *       </sequence>
+     *     </restriction>
+     *   </complexContent>
+     * </complexType>
+     * }</pre>
      * 
      * 
      */
@@ -266,14 +306,22 @@ public class ValidationReportType {
     })
     public static class EgidAttribution {
 
+        /**
+         * Identifikation der Person, auf welche sich diese Zuteilung bezieht.
+         * 
+         */
         @XmlElement(required = true)
         protected PersonIdentificationType personIdentification;
+        /**
+         * Gebäudeidentifikator, der vom BFS zugeteilt wurde.
+         * 
+         */
         @XmlElement(name = "EGID")
         @XmlSchemaType(name = "unsignedInt")
         protected long egid;
 
         /**
-         * Gets the value of the personIdentification property.
+         * Identifikation der Person, auf welche sich diese Zuteilung bezieht.
          * 
          * @return
          *     possible object is
@@ -291,6 +339,7 @@ public class ValidationReportType {
          *     allowed object is
          *     {@link PersonIdentificationType }
          *     
+         * @see #getPersonIdentification()
          */
         public void setPersonIdentification(PersonIdentificationType value) {
             this.personIdentification = value;
@@ -301,7 +350,7 @@ public class ValidationReportType {
         }
 
         /**
-         * Gets the value of the egid property.
+         * Gebäudeidentifikator, der vom BFS zugeteilt wurde.
          * 
          */
         public long getEGID() {
@@ -331,22 +380,22 @@ public class ValidationReportType {
 
 
     /**
-     * <p>Java class for anonymous complex type.
+     * <p>Java class for anonymous complex type</p>.
      * 
-     * <p>The following schema fragment specifies the expected content contained within this class.
+     * <p>The following schema fragment specifies the expected content contained within this class.</p>
      * 
-     * <pre>
-     * &lt;complexType&gt;
-     *   &lt;complexContent&gt;
-     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
-     *       &lt;sequence&gt;
-     *         &lt;element name="personIdentification" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationType"/&gt;
-     *         &lt;element name="errorInfo" type="{http://www.ech.ch/xmlns/eCH-0099/1}errorInfoType" maxOccurs="unbounded"/&gt;
-     *       &lt;/sequence&gt;
-     *     &lt;/restriction&gt;
-     *   &lt;/complexContent&gt;
-     * &lt;/complexType&gt;
-     * </pre>
+     * <pre>{@code
+     * <complexType>
+     *   <complexContent>
+     *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+     *       <sequence>
+     *         <element name="personIdentification" type="{http://www.ech.ch/xmlns/eCH-0044/1}personIdentificationType"/>
+     *         <element name="errorInfo" type="{http://www.ech.ch/xmlns/eCH-0099/1}errorInfoType" maxOccurs="unbounded"/>
+     *       </sequence>
+     *     </restriction>
+     *   </complexContent>
+     * </complexType>
+     * }</pre>
      * 
      * 
      */
@@ -357,13 +406,21 @@ public class ValidationReportType {
     })
     public static class PersonError {
 
+        /**
+         * Identifikation der Person, auf welche sich der Fehler bezieht.
+         * 
+         */
         @XmlElement(required = true)
         protected PersonIdentificationType personIdentification;
+        /**
+         * Informationen über den Fehler, der für diese Person gefunden wurde.
+         * 
+         */
         @XmlElement(required = true)
         protected List<ErrorInfoType> errorInfo;
 
         /**
-         * Gets the value of the personIdentification property.
+         * Identifikation der Person, auf welche sich der Fehler bezieht.
          * 
          * @return
          *     possible object is
@@ -381,6 +438,7 @@ public class ValidationReportType {
          *     allowed object is
          *     {@link PersonIdentificationType }
          *     
+         * @see #getPersonIdentification()
          */
         public void setPersonIdentification(PersonIdentificationType value) {
             this.personIdentification = value;
@@ -391,30 +449,35 @@ public class ValidationReportType {
         }
 
         /**
+         * Informationen über den Fehler, der für diese Person gefunden wurde.
+         * 
          * Gets the value of the errorInfo property.
          * 
-         * <p>
-         * This accessor method returns a reference to the live list,
+         * <p>This accessor method returns a reference to the live list,
          * not a snapshot. Therefore any modification you make to the
          * returned list will be present inside the JAXB object.
-         * This is why there is not a <CODE>set</CODE> method for the errorInfo property.
+         * This is why there is not a <CODE>set</CODE> method for the errorInfo property.</p>
          * 
          * <p>
          * For example, to add a new item, do as follows:
+         * </p>
          * <pre>
-         *    getErrorInfo().add(newItem);
+         * getErrorInfo().add(newItem);
          * </pre>
          * 
          * 
          * <p>
          * Objects of the following type(s) are allowed in the list
          * {@link ErrorInfoType }
+         * </p>
          * 
          * 
+         * @return
+         *     The value of the errorInfo property.
          */
         public List<ErrorInfoType> getErrorInfo() {
             if (errorInfo == null) {
-                errorInfo = new ArrayList<ErrorInfoType>();
+                errorInfo = new ArrayList<>();
             }
             return this.errorInfo;
         }

--- a/src/test/resources/ref/ch/ech/xmlns/ech_0099/_1/package-info.java
+++ b/src/test/resources/ref/ch/ech/xmlns/ech_0099/_1/package-info.java
@@ -1,2 +1,2 @@
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.ech.ch/xmlns/eCH-0099/1", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://www.ech.ch/xmlns/eCH-0099/1", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package ch.ech.xmlns.ech_0099._1;


### PR DESCRIPTION
Hi,

This PR migrates plugin to new Jakarta namespace (jakarta.* instead of javax.*). It works with version 3.x of the `jaxb-maven-plugin` plugin (from org.jvnet.jaxb, see updated documentation).

I suggest to increment version to 3.0.0-SNAPSHOT before merging this PR.

Thanks in advance !